### PR TITLE
Update title feat extraction to create wordcount vecs

### DIFF
--- a/notebooks/data-sources/oc-github-repo/github_PR_EDA.ipynb
+++ b/notebooks/data-sources/oc-github-repo/github_PR_EDA.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "b90b7abe",
+   "id": "6bb0d683",
    "metadata": {},
    "source": [
     "# GitHub Data for OpenShift Origins\n",
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "720db81f",
+   "id": "91b76eb9",
    "metadata": {},
    "source": [
     "## Data Collection:\n",
@@ -25,7 +25,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "a4ee5e0c",
+   "id": "0a1e8c9b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,8 +33,9 @@
     "import gzip\n",
     "import json\n",
     "import boto3\n",
-    "import datetime\n",
     "import pathlib\n",
+    "import datetime\n",
+    "from tqdm import tqdm\n",
     "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -54,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "9fdeeed1",
+   "id": "e4f8861a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,8 +72,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "88bcc4e4",
+   "execution_count": 3,
+   "id": "03e08307",
    "metadata": {},
    "outputs": [
     {
@@ -112,8 +113,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "880c3a74",
+   "execution_count": 4,
+   "id": "7152f231",
    "metadata": {},
    "outputs": [
     {
@@ -122,7 +123,7 @@
        "(17183, 15)"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -133,8 +134,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "084be5e5",
+   "execution_count": 5,
+   "id": "0e64b106",
    "metadata": {},
    "outputs": [
     {
@@ -250,7 +251,7 @@
        "26099           [test/extended/prometheus/prometheus.go]  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -261,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e928179",
+   "id": "76718ceb",
    "metadata": {},
    "source": [
     "## Inspect the dataset\n",
@@ -271,8 +272,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "0aabb217",
+   "execution_count": 6,
+   "id": "16924e83",
    "metadata": {},
    "outputs": [
     {
@@ -296,7 +297,7 @@
        "Name: 26096, dtype: object"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -308,7 +309,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50012df5",
+   "id": "e903d03c",
    "metadata": {},
    "source": [
     "</br>\n",
@@ -334,8 +335,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "e7b35c4e",
+   "execution_count": 7,
+   "id": "50f10ae4",
    "metadata": {},
    "outputs": [
     {
@@ -347,7 +348,7 @@
        " 'openshift-ci[bot]': 79}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -358,7 +359,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ba4acac",
+   "id": "cd3dbeb1",
    "metadata": {},
    "source": [
     "**interactions**: a dictionary with usernames for keys and the number of times they interacted with the PR as the value."
@@ -366,8 +367,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "0c95d34a",
+   "execution_count": 8,
+   "id": "9f419374",
    "metadata": {},
    "outputs": [
     {
@@ -379,7 +380,7 @@
        "  'state': 'APPROVED'}}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -390,7 +391,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e98575f6",
+   "id": "3c145458",
    "metadata": {},
    "source": [
     "**reviews**: a dictionary of reviews that includes an id number key along with fields for author, word_count, submitted timestamp and state of review."
@@ -398,8 +399,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "a5c70e5c",
+   "execution_count": 9,
+   "id": "3c4d3b99",
    "metadata": {},
    "outputs": [
     {
@@ -408,7 +409,7 @@
        "['approved', 'bugzilla/severity-high', 'bugzilla/valid-bug', 'lgtm']"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -419,7 +420,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d132b073",
+   "id": "bbcc501d",
    "metadata": {},
    "source": [
     "**labels**: a list of labels tagged to the PR describing some of its attributes"
@@ -427,8 +428,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "f9a8c61c",
+   "execution_count": 10,
+   "id": "5975e922",
    "metadata": {},
    "outputs": [
     {
@@ -437,7 +438,7 @@
        "['06830a927241a44ae24e9a4b5b2ac75f666d36bc']"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -448,7 +449,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6eb76aff",
+   "id": "953b1574",
    "metadata": {},
    "source": [
     "**commits**: a list of commit hashes that point to specific changes made to the repo's history"
@@ -456,8 +457,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "9507c125",
+   "execution_count": 11,
+   "id": "95d88f67",
    "metadata": {},
    "outputs": [
     {
@@ -474,7 +475,7 @@
        " 'test/extended/testdata/cmd/test/cmd/images.sh']"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -486,7 +487,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8aa8e1d6",
+   "id": "fb4b0da7",
    "metadata": {},
    "source": [
     "**changed_files**: a list of the paths and filenames for every file changed by this PR."
@@ -494,7 +495,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e21c8bd0",
+   "id": "605e237d",
    "metadata": {},
    "source": [
     "We now know what we have access to in this dataset. It is a collection of numerical, categorical and textual features used to describe a PR. This gives us a lot of potential avenues to explore from an EDA and Data Science perspective. But is also creates an additional challenge insofar as we'll need to do a bit of feature engineering to get this data into format that is ready to be ingested by any ML models. "
@@ -502,7 +503,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b7d7a27e-9314-4c85-8cee-69d1f2e4f58d",
+   "id": "ca4610f8",
    "metadata": {},
    "source": [
     "-------------------------------------------------"
@@ -510,7 +511,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "341a8138",
+   "id": "dbd374f9",
    "metadata": {},
    "source": [
     "## Feature engineering\n",
@@ -520,7 +521,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c6931261-983f-4127-83a8-765fad364318",
+   "id": "121e6677",
    "metadata": {},
    "source": [
     "**Time to Merge**\n",
@@ -530,8 +531,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "5df65b84",
+   "execution_count": 12,
+   "id": "d8365a95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -543,7 +544,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e9752c7",
+   "id": "435b733e",
    "metadata": {},
    "source": [
     "Let's look at the distribution of the time to merge column. This can help us determine what the setup for ML problems such as [#236](https://github.com/aicoe-aiops/ocp-ci-analysis/issues/236) could be like. That is, should the time to merge problem be framed as a regression or classification problem.\n",
@@ -553,8 +554,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "5aaeb500",
+   "execution_count": 13,
+   "id": "2b6b8079",
    "metadata": {
     "tags": []
    },
@@ -576,7 +577,7 @@
        "Name: time_to_merge, Length: 186, dtype: float64"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -595,8 +596,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "e5f91fa8",
+   "execution_count": 14,
+   "id": "9a384cda",
    "metadata": {},
    "outputs": [
     {
@@ -621,7 +622,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6c8a9fc",
+   "id": "14d9a0e8",
    "metadata": {},
    "source": [
     "From the above graph we can see that if we bucket the data into days, then roughly 40% of the data points would have the value \"1\", 15% would have the value \"2\" and so on. Therefore we need to select a finer granularity. "
@@ -629,8 +630,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "d8b12b9c",
+   "execution_count": 15,
+   "id": "d086ea1c",
    "metadata": {
     "tags": []
    },
@@ -652,7 +653,7 @@
        "Name: time_to_merge, Length: 691, dtype: float64"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -671,8 +672,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "7447d8df",
+   "execution_count": 16,
+   "id": "97f0c0e6",
    "metadata": {},
    "outputs": [
     {
@@ -697,7 +698,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bd8fa62",
+   "id": "5a231f24",
    "metadata": {},
    "source": [
     "From the above outputs we can see that if we bucket the data into 3 hours, then roughly 10% of the data points would have the value \"1\", 10% would have the value \"2\", 5% would have the value 3, and so on. This is a slightly better value distribution than before, but could be made even better. Lets explore what this would look like with an \"hours\" granularity."
@@ -705,8 +706,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "06f6ae85",
+   "execution_count": 17,
+   "id": "8c6babdd",
    "metadata": {
     "tags": []
    },
@@ -728,7 +729,7 @@
        "Name: time_to_merge, Length: 1314, dtype: float64"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -747,8 +748,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "ca356da7",
+   "execution_count": 18,
+   "id": "270b3e8e",
    "metadata": {},
    "outputs": [
     {
@@ -773,7 +774,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b31ebac",
+   "id": "38a2752d",
    "metadata": {},
    "source": [
     "From the above outputs we can see that if we bucket the data into hours, then roughly 3% of the data points would have the value \"2\", 3% would have the value \"3\", 3% would have the value \"4\", and so on. This seems like a reasonable distribution of values for a regression problem, since the data does not get skewed towards any one particular value.\n",
@@ -783,7 +784,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "067e6f3b",
+   "id": "9f01a838",
    "metadata": {},
    "source": [
     "Now, lets try to determine, if we were to set this up as a classification problem, what the output classes should be. In the following cell, we'll try to split the time-to-merge values into 10 equally populated buckets."
@@ -791,8 +792,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "id": "1e857e2d",
+   "execution_count": 19,
+   "id": "c8b449f4",
    "metadata": {},
    "outputs": [
     {
@@ -811,7 +812,7 @@
        "Name: time_to_merge, dtype: float64"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -827,8 +828,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "834b69c9",
+   "execution_count": 20,
+   "id": "badc559e",
    "metadata": {},
    "outputs": [
     {
@@ -847,7 +848,7 @@
        "Name: time_to_merge, dtype: float64"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -859,7 +860,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93345155",
+   "id": "13f8ac92",
    "metadata": {},
    "source": [
     "If we want to frame our ML problem as a classification problem, we can use the above buckets to define the classes. That is, class 0 is \"merged within 3 hours\", class 1 is \"merged within 3-7 hours\", etc."
@@ -867,7 +868,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e13aee3",
+   "id": "a017a4de",
    "metadata": {},
    "source": [
     "Based on the EDA so far, we cannot conclusively reject either classification or regression. We can explore both of these approaches in depth in forthcoming notebooks and re-evaluate the best setup for this problem."
@@ -875,7 +876,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06d657e5-29e8-4b71-a445-1236dee9f0e8",
+   "id": "b8ccc8c3",
    "metadata": {},
    "source": [
     "**Body**\n",
@@ -885,8 +886,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 21,
+   "id": "0d2e5dbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# derive body_size\n",
+    "pr_df[\"body_size\"] = pr_df[\"body\"].fillna(\"\").apply(lambda x: len(x.split()))"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 22,
-   "id": "3b8f9e43-94d5-4590-8c91-4e82c85c75b7",
+   "id": "c61e0de6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -897,18 +909,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "6434fafe-4622-4eff-8cfb-864c04257f12",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# derive body_size\n",
-    "pr_df[\"body_size\"] = pr_df[\"body\"].fillna(\"\").apply(lambda x: len(x.split()))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "5367359a-d5af-4593-a6fe-7b3a19e48b54",
+   "id": "aac7155c",
    "metadata": {},
    "outputs": [
     {
@@ -1034,7 +1035,7 @@
        "26099         30  "
       ]
      },
-     "execution_count": 24,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1045,23 +1046,66 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa211be5-99ca-44a8-9446-a4616810563c",
+   "id": "f23d2d73",
    "metadata": {},
    "source": [
     "**Title**\n",
     "\n",
-    "Lets try to see if there is anything useful that can be extracted from the PR title."
+    "Lets try to see if the PR title text can be used to extract any useful information regarding the PR."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "b32533d1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "26100    bug 1949306  add e2e test to block usage of re...\n",
+       "26099    bug 1951705  allow highoverallcontrolplanecpu ...\n",
+       "26098    refactor testmultipleimagechangebuildtriggers ...\n",
+       "26097    wip  monitor  move  crashlooping pods  test to...\n",
+       "26096                    bug 1949050  fix images sh script\n",
+       "                               ...                        \n",
+       "5                            add examples for pod creation\n",
+       "4                  wip  added project template json schema\n",
+       "3                        added etcd folder into  gitignore\n",
+       "2                              add alpha api documentation\n",
+       "1                    add link to gopath doc and fixup typo\n",
+       "Name: title, Length: 17183, dtype: object"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# first lets preprocess the text available in the titles\n",
+    "\n",
+    "# convert to lowercase\n",
+    "preproc_titles = pr_df[\"title\"].str.lower()\n",
+    "\n",
+    "# remove punctuations and symbols like : ; , # ( ) [ ] etc\n",
+    "preproc_titles = preproc_titles.str.replace(r'[`#-.?!,:;\\/()\\[\\]\"\\']', ' ', regex=True)\n",
+    "\n",
+    "# remove hash-like strings i.e. 25+ char long strings containing 0-9 or a-f\n",
+    "preproc_titles = preproc_titles.str.replace(r'[0-9a-f]{25,}', ' ', regex=True)\n",
+    "\n",
+    "preproc_titles"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "8b4dac79-2a54-4cca-aa01-2f98cb8305f7",
+   "id": "8e654bd9",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKAAAAJiCAYAAADwqbo5AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Z1A+gAAAACXBIWXMAAAsTAAALEwEAmpwYAABR8ElEQVR4nO3df7zX8/0//ts51SmKUpITbYyVxrz7HSM/YpPfM0zzZhuz4YMxw2ylJpqpxnvMxJvxNo33xmgR2XgbmyUthg0z87sUpZTUOZ3z+v7h0usrVCf17JyO6/Vy6XLp+Xw8n8/X/X5er/N8PV+383w+XxWlUqkUAAAAAChIZWMXAAAAAEDzJoACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKABgg3Puuefm0ksvXen4pZdemoEDB2a33XZbj1UVZ/r06dlvv/2a9DZX95w0RePHj8+wYcNWOv7b3/42X/nKV9ZjRQDQfLVs7AIAgPWjd+/e5f+/8847qaqqSosWLZIk559/fg455JDGKm2dmjlzZq677rr83//9Xzp16tTY5awT/fr1y5QpU5rMNn/729/mN7/5TW666aZ1WtNyxx57bB577LG0bNkyVVVV6d+/f0aMGJEtttgi5557bu644460atUqrVq1yo477pjhw4dnu+22+8B2RowYkUmTJiVJamtrUyqVUlVVlSTp27dvrrnmmvKyr7zySvbZZ5/8/e9/T8uWDpEBYF1zBhQAfEw8+uij5X9du3bN+PHjy9NNOXyqq6tbo+VnzpyZDh06rDR8WrZs2booi4KNGDEijz76aKZMmZK33norF110UXnsG9/4Rh599NE88MAD6dKly0rPYho1alT5NX7iiSdm//33L0+/N3wCAIongAKAj7mampqMHj06u+++e3bfffeMHj06NTU1SZKHH344e+yxR8aPH5+BAwdm8ODB+d3vfveh25k6dWoOPvjg8vRxxx2Xww8/vDx99NFH5w9/+EOS5Lnnnsuxxx6bfv365cADD8y9995bXu7cc8/NyJEj881vfjO9evXKww8/nH/84x857LDD0rt375xxxhlZunTph9bw0EMP5fjjj8+cOXPSu3fvnHvuuXnllVfSo0eP/OY3v8lee+2Vr33ta0mSW265Jfvvv3/69++fb3zjG3n11VfL2/nzn/+cIUOGpG/fvhk1alSOOeaY/OY3v0mSXH755TnrrLPKyy7f/vJga+HChfnBD36Q3XffPYMGDcqll15aDtGWX9J18cUXp3///hk8eHD++Mc/lrc1f/78fP/738/uu++e/v375//9v/+3wvOw3OzZs3Paaadll112yeDBg3PDDTeUxx5//PF86UtfSp8+ffK5z31uheDmvd6/zcGDB+faa6/NwQcfnL59+6705/zcc89l5MiReeyxx9K7d+/069evPPbWW2/lW9/6Vnr37p0jjzwyL7300grrHXfccRkwYED222+/TJ48+UPrer8OHTpkv/32y7PPPvuBsTZt2mT//ffP008/3aBtvd97n8tjjjkmSdK/f//07t07jz766AeWX1UPf/zjH3PAAQekd+/eGTRoUK699tqPVBMANFcCKAD4mLvyyivzt7/9LRMnTszvfve7PPHEE/n5z39eHn/jjTfy5ptv5sEHH8yPf/zjjBgxIv/+978/sJ1evXrlhRdeyLx581JbW5tnnnkmc+bMyaJFi7JkyZI8+eST6du3b2pra3PSSSdlt912y0MPPZThw4fnrLPOWmGbd9xxR0466aTMmDEjO++8c0455ZQceuihmTZtWoYMGZJ77rnnQ3v53Oc+l//+7//OFltskUcffTQ//vGPy2OPPPJIJk+enGuvvTZ/+MMfctVVV+VnP/tZ/vKXv6Rv37757ne/mySZN29eTj311JxxxhmZOnVqPvGJT2TGjBkN/nmee+65admyZe65557cfvvt+fOf/1wOr5J3A6Jtt902U6dOzQknnJBhw4alVColSc4555y88847ufPOO/PQQw/l61//+ge2X19fn5NPPjk9evTIAw88kP/5n//J//zP/+TBBx9MkowePTpf/epXM2PGjPz+97/P/vvv3+Da77rrrlxzzTW5995788wzz+S3v/3tB5bZbrvtcv7556dXr1559NFHM3369PLY5MmTc+qpp+aRRx7JJz7xifI9oRYvXpzjjz8+Bx10UB566KFceumlOf/88/Ovf/1rtTXNmzcvU6ZMSc+ePT8wtnjx4txxxx35xCc+0eAeV+bGG29M8u7r5NFHH13hktWG9DBs2LDyGVd33HFHdtlll7WuCQCaEwEUAHzMTZo0Kaeccko6deqUjh075pRTTvnAWU6nn356qqqqMmDAgOy555656667PrCdNm3a5LOf/WymT5+ev//979lhhx3Sp0+fzJgxI4899lg++clPZrPNNsvf/va3LF68ON/61rdSVVWVXXfdNXvvvXfuvPPO8rb22Wef9O3bN5WVlXnqqadSW1ubr33ta2nVqlWGDBmSz372s2vc52mnnZaNN944bdq0yc0335xvfetb2W677dKyZcucdNJJeeqpp/Lqq6/mgQceyKc//ekMGTIkrVq1yte+9rVsvvnmDXqMN954I3/84x/zgx/8IBtvvHE6deqUr3/96yv01rVr13z5y19OixYtcthhh+X111/PG2+8kTlz5uSBBx7I+eefn/bt26dVq1YZMGDABx7jiSeeKIdkVVVV6datW7785S+Xz8Zp2bJlXnrppcybNy9t27ZNr169GvwzOvbYY9OlS5d06NAhe++9d5566qkGr5sk++67b3beeee0bNkyhxxySHn9+++/P1tttVUOP/zwtGzZMp/5zGey33775e67717pti688ML069cvhx56aDp37pzvf//75bFf/OIX6devX/r06ZO//vWvGTNmzBrV+VGsroeWLVvmX//6VxYtWpT27dtnxx13LLwmANiQuMMiAHzMzZkzJ127di1Pd+3aNXPmzClPb7rpptl4441XOv5e/fv3z7Rp09KlS5f0798/m266aR555JFyeLX88bbccstUVlausM3Zs2eXp6urq1eor0uXLqmoqFhh+TW15ZZblv8/c+bM/OhHP8rFF19cnlcqlTJ79uxyfctVVFSsUM+qzJw5M8uWLcvuu+9enldfX7/C+u8NszbaaKMk755ds2DBgrRv3z7t27df5WO8+uqrmTNnzgqXvtXV1ZWnR48encsuuyz7779/tt5665x66qnZe++9G1R/586dV6htZc/zyry3tzZt2mTx4sXlmh9//PEP1Lyqe48NHz48Rx555IeOHX/88fnOd76TmTNn5oQTTsjzzz+fHXbYYY1qXVOr6+Gyyy7LlVdemZ/85Cfp0aNHvvvd737gLCoA+DgTQAHAx9wWW2yRmTNn5tOf/nSSZNasWdliiy3K42+99VYWL15cDqFmzZpVXvb9BgwYkB//+Mfp2rVrvvnNb6Z9+/Y577zz0qpVq/znf/5n+fFee+211NfXl0OoWbNmZZtttvnQbXbu3DmzZ89OqVQqh1AzZ85Mt27d1qjP9wZY1dXVOemkkz40AHnxxRfz2muvladLpVJmzZpVnt5oo42yZMmS8vQbb7xR/v+WW26ZqqqqTJ06dY2/SW3LLbfMggUL8tZbb2XTTTdd6XLV1dXZeuutV3oZ4jbbbJNLLrkk9fX1ueeee/Ltb387Dz/88Aoh4tp678+yIaqrq9O/f/9cd91166yG5N0gctiwYfne976XvffeO23atPnI21pdT6vrYeedd86VV16Z2traTJgwIWecccYK9/cCgI87l+ABwMfcgQcemCuvvDLz5s3LvHnzcsUVV6xwM/Hk3Zs119TUZPr06bn//vszZMiQD91W79698/zzz+fxxx/PzjvvnE9/+tPlM0f69++f5N0P6m3atMk111yT2traPPzww7nvvvtywAEHfOg2e/XqlZYtW+aGG25IbW1t7rnnnjzxxBNr1fPQoUNz9dVXl29svXDhwvJlhXvuuWeeffbZ3HPPPVm2bFluuOGGFUKmnj175pFHHsnMmTOzcOHCXHXVVeWxLbbYIrvttlt+/OMfZ9GiRamvr89LL72UadOmrbamLbbYInvssUfOP//8LFiwILW1tXnkkUc+sNzOO++ctm3b5uqrr86SJUtSV1eXf/7zn3n88ceTJBMnTsy8efNSWVlZDrLee7bZutCpU6fMnj27fLP61dlrr73ywgsv5Pbbb09tbW1qa2vz+OOP57nnnlvrWnbbbbdsscUW+d///d+12k7Hjh1TWVmZl19++UPHV9VDTU1Nfve732XhwoVp1apV2rZtu85/5gCwofPOCAAfc//v//2/7LTTTjnkkENyyCGHZMcddyx/+1ry7mVVm266aQYNGpSzzjorP/zhD7Pddtt96LY23njj7Ljjjtl+++1TVVWV5N1QqmvXrunUqVOSpKqqKuPHj88DDzyQXXbZJeeff37GjBmz0m1WVVXl8ssvz2233ZYBAwZk8uTJ+fznP79WPX/+85/PCSeckDPPPDN9+vTJQQcdlAceeCDJu0HET3/60/zkJz/JwIED8+KLL6ZPnz7ldXfbbbcccMABOeSQQ/KlL33pA5e3jRkzJrW1tTnggAPSv3//fPvb387rr7/eoLrGjBmTli1bZv/998/nPve5/M///M8HlmnRokXGjx+fp59+Ovvss0922WWXDB8+PIsWLUqSPPjggznwwAPTu3fvjB49OpdeeulanRn0YXbZZZdsv/322X333TNw4MDVLt+uXbtce+21mTx5cgYNGpTdd98948aNa3CAtTonnHBCrrnmmrXa3kYbbZSTTjopX/nKV9KvX7889thjK4yvroeJEydm8ODB6dOnT26++eaMHTt2bVoCgGanorT8a1cAAN7n4Ycfztlnn10OZz6ujj322BxyyCErvScRAACr5gwoAAAAAAolgAIAAACgUC7BAwAAAKBQzoACAAAAoFACKAAAAAAKJYACAAAAoFAtG7uAxvTmm2+nvt4tsAAAAADWVmVlRTbbrO2Hjn2sA6j6+pIACgAAAKBgLsEDAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKtV4CqDfffDPf/OY3s99+++Xggw/Oqaeemnnz5iVJHnvssRxyyCHZb7/9cvzxx2fu3Lnl9T7qGAAAAABNx3oJoCoqKnLCCSdkypQpmTRpUrp165Zx48alvr4+Z599dkaMGJEpU6akX79+GTduXJJ85DEAAAAAmpb1EkB16NAhAwcOLE/36tUrM2fOzJNPPpnWrVunX79+SZKhQ4fm7rvvTpKPPAYAAABA07Le7wFVX1+fm266KYMHD86sWbPStWvX8ljHjh1TX1+f+fPnf+QxAAAAAJqWluv7AS+44IJsvPHGOeaYY/L73/9+fT/8Cjp1ateojw8AAADwcbBeA6iLL744L774YsaPH5/KyspUV1dn5syZ5fF58+alsrIyHTp0+Mhja2Lu3EWpry+tdV8AAAAAH3eVlRUrPdlnvV2Cd8kll+TJJ5/MFVdckaqqqiTJTjvtlCVLlmT69OlJkptvvjlDhgxZqzEAAAAAmpaKUqlU+ClAzz77bA466KBss802adOmTZJk6623zhVXXJEZM2Zk5MiRWbp0abbaaquMHTs2m2++eZJ85LGGev8ZUB3bt0mLqlbrqOv1o66mNvMWLGnsMgAAAICPuVWdAbVeAqim6v0BVOfOm+T1K29sxIrWXOeTj8nrry9s7DIAAACAj7kmcQkeAAAAAB9PAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQLRu7ANafju1bp0VVVWOXsUbqamoyb8HSxi4DAAAAWAsCqI+RFlVVee3KCxu7jDWy5cnDkwigAAAAYEPmEjwAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACtVyfT3QxRdfnClTpuTVV1/NpEmT0r1797zyyis55ZRTysssXLgwixYtyrRp05IkgwcPTlVVVVq3bp0kOeusszJo0KAkyWOPPZYRI0Zk6dKl2WqrrTJ27Nh06tRpfbUDAAAAQAOttwBqn332yVe/+tX853/+Z3ne1ltvnYkTJ5anR48enbq6uhXWu+yyy9K9e/cV5tXX1+fss8/ORRddlH79+uXnP/95xo0bl4suuqjYJgAAAABYY+vtErx+/fqlurp6peM1NTWZNGlSDj/88NVu68knn0zr1q3Tr1+/JMnQoUNz9913r7NaAQAAAFh31tsZUKtz3333pUuXLtlxxx1XmH/WWWelVCqlb9++OfPMM7Pppptm1qxZ6dq1a3mZjh07pr6+PvPnz0+HDh3Wc+UAAAAArEqTCaBuvfXWD5z9NGHChFRXV6empiajR4/OqFGjMm7cuHX2mJ06tVtn22pMnTtv0tglFKq59wcAAADNXZMIoGbPnp1HHnkkY8aMWWH+8kv2qqqqcvTRR+fkk08uz585c2Z5uXnz5qWysnKNz36aO3dR6utL5ekNNeh4/fWFDVquufcHAAAANJ7KyoqVnuyz3u4BtSq33XZb9txzz2y22WbleYsXL87Che8GD6VSKZMnT07Pnj2TJDvttFOWLFmS6dOnJ0luvvnmDBkyZP0XDgAAAMBqrbczoC688MLcc889eeONN3LcccelQ4cOufPOO5O8G0ANGzZsheXnzp2b0047LXV1damvr892222XkSNHJkkqKyszZsyYjBw5MkuXLs1WW22VsWPHrq9WAAAAAFgDFaVSqbT6xZqnD7sE7/Urb2zEitZc55OPWaNL8F678sKCK1q3tjx5uEvwAAAAYAPQ5C/BAwAAAKD5EkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFatnYBcC6sln7qrSsat3YZayRZTVL8+aCmsYuAwAAAAolgKLZaFnVOk9fcWhjl7FGdjhlYhIBFAAAAM2bS/AAAAAAKJQACgAAAIBCuQQPNhAb2j2u3N8KAACA5QRQsIFoWdU69//3gY1dRoPt9c074/5WAAAAJC7BAwAAAKBgAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQ6y2AuvjiizN48OD06NEj//znP8vzBw8enCFDhuTQQw/NoYcemgcffLA89thjj+WQQw7Jfvvtl+OPPz5z585t0BgAAAAATcd6C6D22WefTJgwIVtttdUHxi677LJMnDgxEydOzKBBg5Ik9fX1OfvsszNixIhMmTIl/fr1y7hx41Y7BgAAAEDTst4CqH79+qW6urrByz/55JNp3bp1+vXrlyQZOnRo7r777tWOAQAAANC0tGzsApLkrLPOSqlUSt++fXPmmWdm0003zaxZs9K1a9fyMh07dkx9fX3mz5+/yrEOHTo0QgcAAAAArEyjB1ATJkxIdXV1ampqMnr06IwaNWq9XU7XqVO79fI4RevceZPGLqFQ+ttwNefeAAAAaLhGD6CWX5ZXVVWVo48+OieffHJ5/syZM8vLzZs3L5WVlenQocMqx9bE3LmLUl9fKk9vqB+WX399YYOW01/T1Jz7a2hvAAAAbPgqKytWerLPersH1IdZvHhxFi589wNqqVTK5MmT07NnzyTJTjvtlCVLlmT69OlJkptvvjlDhgxZ7RgAAAAATct6OwPqwgsvzD333JM33ngjxx13XDp06JDx48fntNNOS11dXerr67Pddttl5MiRSZLKysqMGTMmI0eOzNKlS7PVVltl7Nixqx0DAAAAoGlZbwHU8OHDM3z48A/Mv/3221e6Tp8+fTJp0qQ1HgMAAACg6WjUS/AAAAAAaP4EUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUquX6eqCLL744U6ZMyauvvppJkyale/fuefPNN3POOefkpZdeSlVVVT75yU9m1KhR6dixY5KkR48e6d69eyor383JxowZkx49eiRJ7rvvvowZMyZ1dXXZcccdc9FFF2WjjTZaX+0AAAAA0EDr7QyoffbZJxMmTMhWW21VnldRUZETTjghU6ZMyaRJk9KtW7eMGzduhfVuvvnmTJw4MRMnTiyHT2+//XbOO++8jB8/Pr///e/Ttm3bXHvtteurFQAAAADWwHoLoPr165fq6uoV5nXo0CEDBw4sT/fq1SszZ85c7bYeeOCB7LTTTtlmm22SJEOHDs1dd921TusFAAAAYN1Yb5fgrU59fX1uuummDB48eIX5xx57bOrq6rLHHnvktNNOS1VVVWbNmpWuXbuWl+natWtmzZq1vksGAAAAoAGaTAB1wQUXZOONN84xxxxTnnf//fenuro6ixYtytlnn50rrrgi3/nOd9bZY3bq1G6dbasxde68SWOXUCj9bbiac28AAAA0XJMIoC6++OK8+OKLGT9+fPmG40nKl+y1a9cuRx55ZK677rry/Icffri83MyZMz9weV9DzJ27KPX1pfL0hvph+fXXFzZoOf01Tc25v4b2BgAAwIavsrJipSf7rLd7QK3MJZdckieffDJXXHFFqqqqyvMXLFiQJUuWJEmWLVuWKVOmpGfPnkmSQYMG5YknnsgLL7yQ5N0ble+///7rvXYAAAAAVm+9nQF14YUX5p577skbb7yR4447Lh06dMh//dd/5aqrrso222yToUOHJkm23nrrXHHFFfn3v/+dESNGpKKiIsuWLUvv3r1z+umnJ3n3jKhRo0blxBNPTH19fXr27Jlhw4atr1YAAAAAWAPrLYAaPnx4hg8f/oH5zzzzzIcu37t370yaNGml29t3332z7777rrP6AAAAAChGo1+CBwAAAEDzJoACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFAtG7sAgA7tq9KqqnVjl7FGamuWZv6CmsYuAwAAYIMggAIaXauq1rnluiGNXcYaOeK4u5MIoAAAABrCJXgAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChGhxAXXvttR86/7rrrltnxQAAAADQ/DQ4gLriiis+dP6VV165zooBAAAAoPlpuboF/vKXvyRJ6uvrM3Xq1JRKpfLYK6+8krZt2xZXHQAAAAAbvNUGUMOGDUuSLF26ND/4wQ/K8ysqKtK5c+cMHz68uOoAAAAA2OCtNoC67777kiTnnHNOxowZU3hBAAAAADQvqw2glntv+FRfX7/CWGWlL9MDAAAA4MM1OID6+9//nlGjRuWZZ57J0qVLkySlUikVFRV56qmnCisQAAAAgA1bgwOoc889N3vvvXd+9KMfpU2bNkXWBAAAAEAz0uAA6tVXX813vvOdVFRUFFkPAAAAAM1Mg2/e9PnPfz5/+tOfiqwFAAAAgGaowWdALV26NKeeemr69u2bzTfffIUx344HAAAAwMo0OIDafvvts/322xdZCwAAAADNUIMDqFNPPbXIOgAAAABophocQP3lL39Z6diuu+66TooBAAAAoPlpcAA1bNiwFabffPPN1NbWpkuXLrn33nvXeWEAAAAANA8NDqDuu+++Fabr6upy5ZVXpm3btuu8KAAAAACaj8qPumKLFi1y0kkn5ZprrlmX9QAAAADQzHzkACpJ/vznP6eiomJd1QIAAABAM9TgS/D23HPPFcKmd955JzU1NRk5cmQhhQEAAADQPDQ4gBo7duwK0xtttFG23XbbtGvXbp0XBQAAAEDz0eAAasCAAUmS+vr6vPHGG9l8881TWblWV/ABAAAA8DHQ4ARp0aJFOeecc7Lzzjtnjz32yM4775zvfe97WbhwYZH1AQAAALCBa3AAdeGFF+add97JpEmT8vjjj2fSpEl55513cuGFFxZZHwAAAAAbuAYHUA8++GDGjBmTbbfdNlVVVdl2221z0UUX5cEHH1ztuhdffHEGDx6cHj165J///Gd5/vPPP5+jjjoq++23X4466qi88MILaz0GAAAAQNPS4ACqdevWmTdv3grz3nzzzVRVVa123X322ScTJkzIVltttcL8kSNH5uijj86UKVNy9NFHZ8SIEWs9BgAAAEDT0uAA6ogjjsjxxx+fm266KX/84x9z00035Rvf+EaOPPLI1a7br1+/VFdXrzBv7ty5+cc//pGDDjooSXLQQQflH//4R+bNm/eRxwAAAABoehr8LXgnn3xyunTpkkmTJmXOnDnZYostcsIJJzQogPows2bNSpcuXdKiRYskSYsWLbLFFltk1qxZKZVKH2msY8eOa1RDp07tPlLtTU3nzps0dgmF0t+Gqzn3ljT//gAAANaVBgdQo0ePzgEHHJDrr7++PG/GjBkZPXp0hg0bVkRthZs7d1Hq60vl6Q31w+Trrzfsmwj11zQ15/6ac29Jw/sDAAD4OKisrFjpyT4NvgTvjjvuyE477bTCvJ122il33HHHRyqquro6s2fPTl1dXZKkrq4uc+bMSXV19UceAwAAAKDpaXAAVVFRkfr6+hXm1dXVfWBeQ3Xq1Ck9e/YsB1h33HFHevbsmY4dO37kMQAAAACangYHUP369ctPf/rTcuBUX1+fyy+/PP369VvtuhdeeGH22GOPvPbaaznuuONy4IEHJkl++MMf5sYbb8x+++2XG2+8Meeff355nY86BgAAAEDT0uB7QA0bNiwnnnhidt9993Tt2jWzZs1K586dM378+NWuO3z48AwfPvwD87fbbrv85je/+dB1PuoYAAAAAE1LgwOoLbfcMrfddlsef/zxzJo1K9XV1dl5551TWdngk6gAAAAA+BhqcACVJJWVlenVq1d69epVUDkAAAAANDdOXwIAAACgUAIoAAAAAAolgAIAAACgUAIoAAAAAAolgAIAAACgUAIoAAAAAAolgAIAAACgUC0buwCA5q59h1apatWmsctYIzW1S7Jgfm1jlwEAADQTAiiAglW1apOrfrlfY5exRk48dkoSARQAALBuuAQPAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEK1bOwCANiwte/QKlWt2jR2GWukpnZJFsyvbewyAADgY0MABcBaqWrVJj/89X6NXcYa+eGXpyQRQAEAwPriEjwAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACtWysQsAgKZskw5VadOqdWOXsUaW1C7Nwvk1jV0GAACUCaAAYBXatGqd/Sce3thlrJG7Dr01CyOAAgCg6XAJHgAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCg3IQeAj7FNOrROm1ZVjV1Ggy2prcnC+UsbuwwAANaQAAoAPsbatKrKAbdd2NhlNNjkw4ZnYQRQAAAbGpfgAQAAAFAoARQAAAAAhRJAAQAAAFAoARQAAAAAhRJAAQAAAFCoRv8WvFdeeSWnnHJKeXrhwoVZtGhRpk2blsGDB6eqqiqtW7dOkpx11lkZNGhQkuSxxx7LiBEjsnTp0my11VYZO3ZsOnXq1Cg9AAAAALByjR5Abb311pk4cWJ5evTo0amrqytPX3bZZenevfsK69TX1+fss8/ORRddlH79+uXnP/95xo0bl4suumi91Q0AAABAwzSpS/BqamoyadKkHH744atc7sknn0zr1q3Tr1+/JMnQoUNz9913r48SAQAAAFhDjX4G1Hvdd9996dKlS3bcccfyvLPOOiulUil9+/bNmWeemU033TSzZs1K165dy8t07Ngx9fX1mT9/fjp06NDgx+vUqd26LL/RdO68SWOXUCj9bbiac2+J/jZ0+ttwNefeAACaqyYVQN16660rnP00YcKEVFdXp6amJqNHj86oUaMybty4dfZ4c+cuSn19qTy9oR7Qvv76wgYtp7+mqTn315x7S/S3nP6apubcX0N7AwBg/aqsrFjpyT5N5hK82bNn55FHHsnBBx9cnlddXZ0kqaqqytFHH50ZM2aU58+cObO83Lx581JZWblGZz8BAAAAsH40mQDqtttuy5577pnNNtssSbJ48eIsXPjuXzhLpVImT56cnj17Jkl22mmnLFmyJNOnT0+S3HzzzRkyZEjjFA4AAADAKjWZS/Buu+22DBs2rDw9d+7cnHbaaamrq0t9fX222267jBw5MklSWVmZMWPGZOTIkVm6dGm22mqrjB07trFKBwAAAGAVmkwANWXKlBWmu3Xrlttvv32ly/fp0yeTJk0quCoAAAAA1laTuQQPAAAAgOZJAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABSqyXwLHgDAurRJhzZp06pVY5exRpbU1mbh/CWNXQYAwDongAIAmqU2rVrlwN9e2dhlrJE7v3RyFkYABQA0Py7BAwAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQAigAAAAACiWAAgAAAKBQLRu7AAAA1twmHdqkTatWjV3GGllSW5uF85c0dhkAQCMQQAEAbIDatGqVg26Z0NhlrJE7jvjPLIwACgA+jlyCBwAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChWjZ2AQAA8H6bdNgobVptWIeqS2qXZeH8dxq7DABokjasd3UAAD4W2rRqmUNumdTYZayR3x1xcBY2dhEA0ES5BA8AAACAQjWJM6AGDx6cqqqqtG7dOkly1llnZdCgQXnssccyYsSILF26NFtttVXGjh2bTp06JckqxwAAAABoOprMGVCXXXZZJk6cmIkTJ2bQoEGpr6/P2WefnREjRmTKlCnp169fxo0blySrHAMAAACgaWkyAdT7Pfnkk2ndunX69euXJBk6dGjuvvvu1Y4BAAAA0LQ0iUvwkncvuyuVSunbt2/OPPPMzJo1K127di2Pd+zYMfX19Zk/f/4qxzp06NDgx+zUqd26bKHRdO68SWOXUCj9bbiac2+J/jZ0+ttwNefeEv1t6Jp7fwDwUTWJAGrChAmprq5OTU1NRo8enVGjRuXzn/984Y87d+6i1NeXytMb6gHD66837PtW9Nc0Nef+mnNvif6W01/T1Jz7a869Jfpbrrn3BwDNUWVlxUpP9mkSAVR1dXWSpKqqKkcffXROPvnkfPWrX83MmTPLy8ybNy+VlZXp0KFDqqurVzoGAABN3SYdNkqbVk3iULzBltQuy8L57zR2GQBsoBr9XW/x4sWpq6vLJptsklKplMmTJ6dnz57ZaaedsmTJkkyfPj39+vXLzTffnCFDhiTJKscAAKCpa9OqZQ679U+NXcYaue3w3eP8LgA+qkYPoObOnZvTTjstdXV1qa+vz3bbbZeRI0emsrIyY8aMyciRI7N06dJstdVWGTt2bJKscgwAAACApqXRA6hu3brl9ttv/9CxPn36ZNKkSWs8BgAANJ5NOmycNq1aNHYZDbakti4L5y9u7DIAmrVGD6AAAIDmpU2rFjnqt/9q7DIa7H+/tH2DLy9s36FtqlpVFlrPulZTW58F899u7DKAjzkBFAAAQANVtarMFbfNbuwy1sgph3Vp7BIAsmFF9wAAAABscARQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABSqZWMXAAAAQNPQoUPbtGq1YZ2nUFtbn/nz327sMoDVEEABAACQJGnVqjJ3/e8bjV3GGtn/qM0buwSgATasaBsAAACADY4ACgAAAIBCuQQPAACAj4XN2rdNy6oN6zyMZTX1eXOBe1yx4RNAAQAA8LHQsqoyj14zp7HLWCO9T9iiwct2bL9xWlS1KLCada+upi7zFixu7DJYDwRQAAAA0Ay0qGqRWWNebewy1kj1OVs1dgmsJxvWuYcAAAAAbHAEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKF8Cx4AAADQ5HVsv3FaVLVo7DIarK6mLvMWLG7sMpoMARQAAADQ5LWoapHZ//XXxi6jwbqc0bfBy3Zsv1FaVG1YEU1dzbLMW/BOg5ffsLoDAAAAaGZaVLXMnJ/d09hlrJEtTv3CGi3vHlAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFKplYxfw5ptv5pxzzslLL72UqqqqfPKTn8yoUaPSsWPH9OjRI927d09l5bs52ZgxY9KjR48kyX333ZcxY8akrq4uO+64Yy666KJstNFGjdkKAAAAAB+i0c+AqqioyAknnJApU6Zk0qRJ6datW8aNG1cev/nmmzNx4sRMnDixHD69/fbbOe+88zJ+/Pj8/ve/T9u2bXPttdc2VgsAAAAArEKjB1AdOnTIwIEDy9O9evXKzJkzV7nOAw88kJ122inbbLNNkmTo0KG56667iiwTAAAAgI+o0S/Be6/6+vrcdNNNGTx4cHnesccem7q6uuyxxx457bTTUlVVlVmzZqVr167lZbp27ZpZs2at8eN16tRundTd2Dp33qSxSyiU/jZczbm3RH8bOv1tuJpzb4n+NnT623A1594S/W3o9Lfhas69JWvWX5MKoC644IJsvPHGOeaYY5Ik999/f6qrq7No0aKcffbZueKKK/Kd73xnnT3e3LmLUl9fKk9vqC+M119f2KDl9Nc0Nef+mnNvif6W01/T1Jz7a869JfpbTn9NU3Purzn3luhvOf01Tc25v+bcW/LB/iorK1Z6sk+jX4K33MUXX5wXX3wx//Vf/1W+6Xh1dXWSpF27djnyyCMzY8aM8vz3XqY3c+bM8rIAAAAANC1NIoC65JJL8uSTT+aKK65IVVVVkmTBggVZsmRJkmTZsmWZMmVKevbsmSQZNGhQnnjiibzwwgtJ3r1R+f77798otQMAAACwao1+Cd6zzz6bq666Kttss02GDh2aJNl6661zwgknZMSIEamoqMiyZcvSu3fvnH766UnePSNq1KhROfHEE1NfX5+ePXtm2LBhjdkGAAAAACvR6AHUpz/96TzzzDMfOjZp0qSVrrfvvvtm3333LaosAAAAANaRJnEJHgAAAADNlwAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEJt0AHU888/n6OOOir77bdfjjrqqLzwwguNXRIAAAAA77NBB1AjR47M0UcfnSlTpuToo4/OiBEjGrskAAAAAN6nZWMX8FHNnTs3//jHP3LdddclSQ466KBccMEFmTdvXjp27NigbVRWVnxw3iZt12md68OH9bEyLTZpX2AlxViT/lptskWBlRRjTfpr027D6m9Netu4XZcCKynGmvTXrm3z7q/Dxs27vy026lxgJcVYo/423rDeG9ast00KrKQYa9Zf8z5u2WLjjQqspBhr0l/njVsXWEkx1qy/Deujxpr0tsnGG97f8dekv42aeX9V7Zp3fy02bVFgJcVYk/4qN60qsJJ1b41626RNgZUU4/39rarfilKpVCq6oCI8+eST+d73vpc777yzPO+AAw7I2LFjs+OOOzZiZQAAAAC814YX/QIAAACwQdlgA6jq6urMnj07dXV1SZK6urrMmTMn1dXVjVwZAAAAAO+1wQZQnTp1Ss+ePXPHHXckSe6444707Nmzwfd/AgAAAGD92GDvAZUkzz33XM4999y89dZb2XTTTXPxxRfnU5/6VGOXBQAAAMB7bNABFAAAAABN3wZ7CR4AAAAAGwYBFAAAAACFEkABAAAAUCgBFAAAAACFEkCtJw8//HC+9KUvrfFYU/OHP/wh+++/f774xS9m5513zpIlSxq7pLX21FNPZfLkyY1dRiF69OiRt99+u7HLKMTll1+empqaRlufNec5+3h45ZVXMnDgwNUu15T2vR9lXzl79uwce+yxDdrG4MGD889//nOtalwThx56aLN4f2btXX755bn44osbuwze473H/Q3dX/LxsqEe7zS1z7Rr89771ltv5b//+7/XcUXr1/PPP59jjz02Q4YMyUEHHZTvf//7TeLYQADFGrn55pvz7W9/O7fffnsef/zxtGnTprFLWmtPPfVU7r777pWOL1u2bD1WQ0P97Gc/S21tbaOtz5prTs+Z/cLaW92+t6nr0qVLfvnLXzZ2GR9q4sSJzeL9GWge3v+euSbvoR+n99vlvTal452Pq7feeivXXHPNR1q3qbxmW7Vqle9///u5++6787vf/S7vvPNOrr322sYuKy0bu4Dm4Lvf/W6ef/751NbW5hOf+ER+9KMfpX379rn00kszefLkbLrpphkwYMAK66xqrKn60Y9+lL/+9a95/vnn86tf/SrTpk3LjBkzsmTJkhx55JH56U9/ms9+9rO57bbb8utf/zq//OUv07JlMS+xV155JYcffngefvjhFaZvvfXWHH744TnssMPy5z//OUkycuTI9OvXL3Pnzs13v/vdzJ07N0my66675uSTT85ll12WRYsW5dBDD03//v0zfPjw9OjRI6eeemruv//+DBo0KCeccEIuuuiiPPPMM1m6dGkGDhyY73//+2nRokV+8Ytf5M4770xdXV1at26dH/7wh+nZs2eSd/8ifsYZZ+QPf/hD5s+fnwsvvDAPPfRQHnzwwSxbtiw//elPs9122xXyM1ru2muvzb333pslS5bkzDPPzH777bfSn9/y6RtvvDE33HBDNtlkk+y5556ZMGFCeawpOP/885MkQ4cOTWVlZa688spcccUVH/r8/OxnP8sdd9yR1q1bp6KiIjfccEMuvfTSFdb/5S9/mU033bQxW/pQK3ueJk+e/IHX8g9+8IMkydVXX5177rkndXV16dKlSy644IJ07ty50XpYrojn7K677sr111+fqqqq1NfX57/+678K/X1ak/3Csccemx133DGPP/54Xn311Xz1q19Nly5dcuONN2bOnDk5++yzs//++ydJHnjggVxyySWpq6tLx44dM2rUqHzyk5/M17/+9RxzzDHZd999kyT/93//l1/84hf55S9/mTlz5uTCCy/MzJkzs3Tp0hx44IE56aST1rrHj7JvTZIJEybk+uuvT7t27bLnnnuWt7ds2bKceOKJefPNN7N06dLsvPPOOf/88/P2229/6L73b3/7W8aNG1c+k+jb3/529tprr7XuqyHWdF/5/rH3mj59evk1379//5RKpfXSw3I9evTIjBkz0rZt2wwePDgHH3xwpk6dmtmzZ5f3HXfccUcWLFiQH/3oR+nfv/9Kn6uqqqrU1NTkggsuyLRp09KxY8f07Nkzb7zxRi677LIkTXe/s9zKfsduueWW3HDDDUnePVC/6qqrsvnmmzdytf+/hh5DvP766znzzDPz9ttvZ+nSpdlzzz1zzjnnfGB7zzzzTM4666ycd9556dWrVy699NI88sgjqampSY8ePfLDH/4wbdu2bYROm68P+4ywKit7rZ555pn5/Oc/n/333z///d//nfHjx2fatGlp0aJFDjjggFxxxRXZdttt11NXK/qw/fb222+fww8/PF/60pcyderUfPnLX87kyZOzww475G9/+1vat2+f8ePHZ9y4cXnwwQeTJIMGDcpZZ52VFi1a5Nxzz02LFi3y/PPP5+23387EiRMLqf2dd97J9773vfzrX/9Ky5Yts+2222bPPffM/fffX96//fa3vy1P//a3v82kSZPSunXrvPTSS9l8880zduzYdOnSZZVjdXV1De61T58+Sdb/MWqPHj1yyimnfOB9MFn56zJpOp9pH3300YwZM6b8Onz/PnDw4MEZP358unfvvsL09ttvn1GjRmXq1KmpqqrKxhtvnJtvvjmjRo3KwoULc+ihh2ajjTbKzTffvMpjr8GDB+eAAw7I1KlT071799X+rq9rqzt+qqyszM4775znnnuuPO+2227Lr371q9TV1aVdu3b54Q9/mE996lPFF1tirc2dO7f8/0suuaQ0duzY0r333ls66KCDSosWLSotW7asdOKJJ5YOO+ywUqlUWuVYU3fMMceU7rvvvlKpVCp17969tGjRolKpVCpNnTq19IUvfKH06KOPlvbaa6/SzJkzC63j5ZdfLg0YMOAD0y+//HKpe/fupdtuu61c16BBg0pLly4tXXfddaXzzjuvvM78+fNLpVKpdOutt5ZOO+20FbbfvXv30lVXXVWe/sEPflDeZl1dXek73/lO6X//939LpdKKz/+f//zn0pFHHrnCdm688cZSqVQqTZ48udSrV6/yz+/qq68uffe73y0ve8ghh5Ree+21j/wz+TDdu3cvXX755aVSqVR67rnnSgMGDCi98cYbK/35lUql0lNPPVXafffdy31dcMEFKyzbVLz39bey5+fNN98s9e3bt/TOO++USqVSaeHChaXa2toPrN9Urex5Wtlr+fbbby8NHz68VFdXVyqVSqUJEyaUzjzzzPVb9Cqs6+esT58+pdmzZ5dKpVJp6dKlpcWLFxdef0P3C8ccc0zp9NNPL9XV1ZVee+210s4771y65JJLSqVSqfS3v/2tNGjQoFKpVCq98cYbpYEDB5aeffbZUqlUKv36178uHXHEEaVS6d3n85RTTik/3qmnnlp+vK9//euladOmlUqld3v/yle+UvrTn/601j1+lH3rU089Vdptt91Kr7/+eqlUKpVGjhxZ3kZ9fX1p3rx55f+fffbZpV/96lelUumD+94FCxaUDj300PJzOnv27NKgQYNKCxYsWOu+Vuej7CvfP7b89bl06dLS7rvvXpo6dWqpVCqV7rzzzlL37t1LzzzzTOF9vL+WUqlU2nvvvUs//vGPS6XSu6+9//iP/yi/L915552loUOHlkqlVT9XN9xwQ+n4448v1dbWlpYsWVI68sgjy89dU9/vrOx3bOrUqaV99923NGfOnFKpVCotWrSotGTJksYs9QMaegyxZMmS8vNdU1NTOvbYY0t//OMfS6VSqXTZZZeVfvzjH5f+/Oc/lw466KDyz+GKK64oXXHFFeXHGjNmTHkfxbrzYZ8Rpk6dWj7uf+9+ZFXvB7/+9a/L7/vHH3986aijjio9+uijpdmzZ5f23HPP9djRila23/7HP/5R6t69e+nOO+8sL3vMMceUTjzxxPJ7+oQJE0pf+9rXSkuXLi0tXbq09NWvfrU0YcKEUqlUKn3ve98rHXbYYaW333670Prvueee0vHHH1+enj9//gfem947feutt5Y++9nPlp577rlSqVQqXX755Q0aW9NeG+MYdWXvg6t6XTaVz7Rvvvlm6XOf+1zpr3/9a6lUKpWWLVtWmj9/fmnvvfcuv/e+9//vnf773/9eGjJkSPk9bPkx9fvf40ulVR977b333qWRI0cW2ufKNOT46Z133ikdcMABpT/84Q+lUqlUeuSRR0rf/OY3S0uXLi2VSqXS/fffXzrqqKPWS73OgFoHJk6cmEmTJqW2tjaLFy/ONttsk9ra2hxwwAHlvyQdccQR+fnPf57k3etjVza2oRo4cGAOOuigHH300fnZz36W6urqRqulVatWOeSQQ8p1tWnTJv/+97/zH//xH7n++utz8cUXZ8CAAdl9991XuZ3DDjus/P/77rsvjz/+eK677rokyZIlS9KlS5ckyZNPPpmrrroqCxYsSEVFRV544YUVtrP8LIcdd9wxSbL33nsnSXbaaaf8/ve/Ly9X1F93jjzyyCTJpz71qXzmM5/JY489lh49eqx0+WnTpmXPPfdMx44dk7z7+pw0aVIhta0rK3t+Ntlkk3ziE5/IOeeck9133z177bVX2rVr18jVrr2VvZbvu+++PPnkk+XX7vK/aDRF6+I522WXXXLuuedm7733zl577ZVu3boVXndD9wtJMmTIkFRWVqZLly7p0KFD+UymHXfcMbNnz87SpUvzt7/9LTvssEO23377JMnhhx+e888/P4sWLcoXvvCFXHTRRXnzzTeTvPu7efHFF2fx4sWZNm1a5s2bV36st99+O88991x22223wnpf2b512rRp2Wuvvcpnjhx11FG56667kiT19fX5xS9+kQceeCD19fVZsGDBSi8Ne/TRR/PKK6/km9/8ZnleRUVFXnzxxXz2s58trK/l1nRfuTL//ve/s9FGG5Xv63LAAQdkxIgR67TWNXXAAQckefe1984775Tfl3baaae89NJLSVb9XD388MM59NBD07Jly7Rs2TIHHnhg/vrXvyZp+vudlf2O3XvvvTn00EPLZ2o11TN/GnIMUVdXlzFjxuTRRx9NqVTKG2+8kaeffjp77LFHkuRPf/pTHnzwwVx77bXlfdR9992XRYsWZcqUKUmSmpqa7LDDDuu1t4+DD/uMMGjQoA9ddlXvB7vsskuuvvrq1NTU5LXXXss3vvGNPPTQQ+natWuj3kNqZfvtZcuWpXXr1uXX73IHH3xw+eqIv/zlLznssMNSVVWVJPnSl76UP/zhDzn66KOTvPseuvHGGxda/w477JDnnnsu559/fgYMGNCgM2779u1bPkvkyCOPzMEHH7zasabQa0N82PtgRUXFSl+XTeUz7WOPPZbtttuufPZYixYt0r59+wat261btyxbtizDhg3LwIEDy/vY92vIsdcXv/jFtWvkI1rd8dOyZcvyne98J7vsskv22WefJO++Bzz99NPl57xUKuWtt95aL/UKoNbS9OnTc9NNN+Xmm29Ox44dM2nSpPz6179u7LIaxT/+8Y907Ngxr732WuGP1bJlyxUuaVi6dOlq1+ndu3duu+22PPTQQ5k4cWKuvvrq3HTTTStd/r1vBKVSKT//+c8/8AG3pqYmp59+em688cbyh8rlB3zLtW7dOsm7pz4uf+NZPt1Y1wh/lJ9fU7ay5ydJfv3rX2fGjBmZOnVqvvSlL+Waa67ZYA6yV/Y8rey1XCqVcvLJJ+eII45orJIbbF08Zz/72c/yxBNPZOrUqfnqV7+aH/7whytc/lWEhuwXllv+u5+8ezC0fLpFixZJVn+PgI022ij77LNP7rjjjiTJPvvsk4033jiLFi1KRUVFbrnllrRq1Wqt+nm/db1vmDRpUv76179mwoQJadeuXcaPH/+BkH65UqmUHj16ZMKECWv1mOvSuvp5VFRUrKuSPpL3v/be+760/HW4Js/Ve21I+50NUUOOIa677rq89dZb+c1vfpPWrVvnvPPOW+G1uu222+bZZ5/Nk08+WQ6gSqVSRo4cmV133XU9drP2br311vJlk9/4xjfKoXhTtC4/I3Tr1i319fW5884706tXr+y6664555xzstVWWzXqc7iy/fYrr7ySjTba6AP7vjUJWdZHINOtW7fccccdmTp1ah544IFceumlOeWUU1JfX19eZn0cIzeF8Km5a9GixYc+r5tssknuvPPOPPzww3nooYcybty43HbbbR9Yv76+frXHXo31PK7q+Kmuri5nnXVW2rdvn+HDh6+wzuGHH57TTz99fZaaxE3I19pbb72Vdu3apUOHDqmpqcmtt96a5N2/zN91111ZvHhx6urqyvNXN7ahuv7667Ns2bL89re/zTXXXJOnnnqq0MfbfPPNU1tbmxdffDFJyh/QkqS2trZ8xs706dOzZMmSfOpTn8rLL7+cdu3a5cADD8z3v//9/P3vf099fX3atWuXhQsXrvLxBg8enKuvvjp1dXVJknnz5uXll19OTU1Nli1bVj7j61e/+lUR7a6V5a+vF154If/4xz/Sq1evVf78BgwYkAceeKCc8H/YTrgpaNu2bRYtWpRk5c/PokWLMm/evAwYMCDf/va307179zz77LMfWL+pWtnztLLX8uDBg/OrX/0qCxYsSPJuQPr00083Wv3vty6fs2XLluXll1/OzjvvnG9961vZbbfdCt/vvN/KelgTvXr1ytNPP12+Jv+2227LZz7zmfIZJIcddlhuu+223HbbbeVvlmnXrl369u2bq6++urydWbNm5fXXX1/rnj7KvnXAgAH54x//WL4n2S233FJeZ+HChdlss83K+9n3bu/9+97evXvnxRdfzNSpU8vzHn/88fV2/6Q13VeuzKc+9aksWbIk06dPT5Lcfffd6+2vimtjVc/VgAEDMmnSpCxbtixLly4tn+GWpMnvd1b2O7bPPvtk4sSJeeONN5KkfP+kDdHChQvTuXPntG7dOrNnz8699967wvhWW22VX/ziF7nkkkvK3zw5ePDgXH/99eVvRFq0aNEK9wZpqg4//PBMnDgxEydObNLhU7Lyzwgrs7r3g1122SWXX355Pve5z6W6ujrz58/Pn/70p0YNoNZmv73rrrvm9ttvT21tbWpra3P77bfnc5/7XJHlfsBrr72WFi1aZN999833v//9zJs3L926dcszzzyTmpqa1NTUlM8SXG7GjBnlcP7WW2/NLrvsstqxNe21sY5RP+x9cFWvy6bymbZXr1557rnn8uijjyZ5N3RZ/p603Cc+8Yk88cQTSd49I235vn/evHl55513yvfl2mSTTcrH2UuWLCkH/UUee62tlf0e1tXVle8xNnr06BUC4cGDB2fixInlE0fq6ury5JNPrpd6nQG1lgYNGpTf/e532W+//bLZZpulX79+eeKJJ7L33nvnsccey6GHHlq+Kdvs2bOTZJVjG6LHH388N9xwQ2655ZZ07NgxF1xwQb7zne/klltuKew0/JYtW2bYsGE57rjj0rFjxxVOme3QoUOefvrp8jcXXHLJJamqqsq0adNy/fXXp7KyMvX19Tn//PNTWVmZXXfdNb/4xS9yyCGHZMCAASukw8v94Ac/yNixY3PooYemoqIirVq1yg9+8IN069Yt3/72t3PEEUekQ4cO5Zv1fRSHHnporr766hUu4VkX6urq8sUvfjHvvPNORo0alU6dOiXJSn9+O+ywQ0444YQMHTq0/OayySabrNOa1oXjjz8+X/3qV9OmTZuMHz8+48eP/8Dz06pVq5x22mlZsmRJSqVSPvOZz+QLX/jCB9ZvqjchX9nrfGWv5S9+8YuZP39+jjnmmCTv/nXjK1/5SpM542tdPmfXXnttzj333CxcuDAVFRWprq7Od7/73fXaz6r2Cw3VsWPHjBkzJmeddVaWLVuWjh07ZuzYseXxfv36lQ9Cl9/wO0nGjRuXiy66qHx6f9u2bTN69Oi1vvHzR9m37rDDDjnppJPyla98Je3atVvhLNAvfvGLuffeezNkyJB06tQpffv2LX/I/7B9789//vOMHTs2P/rRj1JbW5tu3bpl/Pjx6+UMojXdV65MVVVVLrnkkhVuQt61a9ciS18nVvVcDR06NE8//XQOPPDAbLbZZivcpLSp73dW9jv2yU9+Mt/61rdy3HHHpaKiIlVVVRk/fvwKZy5uKI499ticfvrpOeigg9KlS5cPDSSqq6tz/fXX5xvf+EaWLFmSb33rW/nZz36WI444IhUVFamoqMipp55a+BejfJys7DPCyqzu/WDXXXddIdTo27dv/vKXv6zz48Y10b59+w/db5933nmrXfeoo47KSy+9VL58d/fdd8+Xv/zloktewTPPPJOf/OQnSd49w+Vb3/pW+vTpk1133TUHHnhgtthii+ywww4rhAx9+vTJxRdfnBdffLF8o/HVja1pr411jLqy98GVvS6bymfaDh065PLLL8+Pf/zjLF68OJWVlfne9763wjKnn356zj333Nx4443ZZZddyu/Ls2bNynnnnZdly5alrq4ue+yxR3r16pXKysocfPDBOfjgg9O+ffvcfPPNhR17ra2V/R4effTR+d3vfpfu3buX/4jZp0+fjBw5Mv37988ZZ5yRk08+OXV1damtrc2QIUOy0047FV5vRWl9/WkR1oNVfSsRDbdo0aJyeHj55ZfnxRdfzLhx4xq5KqCx2Ley/H2hpqYmJ598coYMGVK+dwTAx8F7vxFvTcY2BO/99lQokjOggA/4yU9+khkzZpQT9FGjRjV2SQA0ouOOOy41NTVZunRpPve5z61wQ34AgIZwBhQAAAAAhXITcgAAAAAKJYACAAAAoFACKAAAAAAKJYACANjAHXvssfnNb37T2GUAAKyUAAoAAACAQgmgAAA2EKVSKfX19Y1dBgDAGhNAAQAU5NZbb81JJ51Unv7CF76Qb3/72+XpPffcM0899VRmzJiRww8/PH379s3hhx+eGTNmlJc59thjc+mll2bo0KH5j//4j7z88sv585//nCFDhqRv374ZNWpUSqVSefkXX3wxxxxzTPr27ZuBAwfmjDPOWC+9AgCsigAKAKAgAwYMyPTp01NfX5/Zs2entrY2jz32WJLk5ZdfzuLFi1NdXZ0TTzwxxx57bB5++OEcd9xxOfHEE/Pmm2+WtzNx4sRccMEFmTFjRjbZZJOceuqpOeOMMzJ16tR84hOfWCGw+ulPf5rddtstjzzySB544IEcc8wx67ttAIAPEEABABSkW7duadu2bZ566qlMnz49u+++e7bYYos899xzmTZtWvr27Zv7778/n/zkJ/PFL34xLVu2zEEHHZRPfepT+b//+7/ydg477LB8+tOfTsuWLfPAAw/k05/+dIYMGZJWrVrla1/7WjbffPPysi1btszMmTMzZ86ctG7dOv369WuM1gEAViCAAgAoUP/+/TNt2rQ88sgj6d+/fwYMGJBHHnkkjzzySAYMGJA5c+aka9euK6zTtWvXzJ49uzxdXV1d/v+cOXOy5ZZblqcrKipWGD/77LNTKpVyxBFH5MADD8wtt9xSYHcAAA3TsrELAABozgYMGJD77rsvr776ak466aRsuummmTRpUh599NH853/+Z5577rnMnDlzhXVmzZqVQYMGlacrKirK/+/cuXNee+218nSpVMqsWbNWGL/wwguTJNOnT89xxx2X/v3755Of/GRRLQIArJYzoAAACtS/f/88/PDDWbJkSbbccsv069cvDz74YObPn5/PfOYz2XPPPfPCCy9k0qRJWbZsWSZPnpx//etf2WuvvT50e3vuuWeeffbZ3HPPPVm2bFluuOGGvPHGG+Xxu+66qxxQtW/fPhUVFamsdMgHADQuRyMAAAXadttt07Zt2/K9mNq1a5ett946ffr0SYsWLbLZZptl/Pjxue666zJw4MBcc801GT9+fDp27Pih2+vYsWN++tOf5ic/+UkGDhyYF198MX369CmPP/HEEznyyCPTu3fvnHzyyRk2bFi6deu2XnoFAFiZitJ7v7cXAAAAANYxZ0ABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUKj/D2UJPvTa5g/8AAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKAAAAJiCAYAAADwqbo5AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Z1A+gAAAACXBIWXMAAAsTAAALEwEAmpwYAABU4UlEQVR4nO3df7zX8/0//ts51SkKKUnl52zRmPVbRkNs8mOa4a15Y2M2fObHWCykiEblxzA0Y7xtNhuTVrJszBgjLYb5MTO/S6mUkn6d8/r+4dLrKzp1Ss/OKdfr5dLl0vP5eL6er/v9PF/P5+v1up3n83kqSqVSKQAAAABQkMr6LgAAAACA9ZsACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAgHXOwIEDc8UVV9Q6fsUVV2TXXXfN7rvvvharKs6kSZOy3377Neh1rmybNESjRo3KueeeW+v4nXfemW9+85trsSIAWH81ru8CAIC1o0uXLuX/v//++6mqqkqjRo2SJBdccEEOPvjg+iptjZoyZUpuuumm/OUvf0nr1q3ru5w1onv37pkwYUKDWeedd96Z22+/Pb/5zW/WaE1LHX300XnyySfTuHHjVFVVpUePHhk8eHA233zzDBw4MOPGjUuTJk3SpEmT7LTTThk0aFC23377j61n8ODBGTt2bJJk8eLFKZVKqaqqSpJ069YtN9xwQ3nZN954I/vss0/+9a9/pXFjH5EBYE1zBhQAfEo88cQT5X/t27fPqFGjytMNOXyqrq5epeWnTJmSli1b1ho+LVmyZE2URcEGDx6cJ554IhMmTMi7776biy++uDz2ne98J0888UQefPDBtG3bttazmIYOHVp+jZ9wwgnZf//9y9MfDp8AgOIJoADgU27RokUZNmxY9thjj+yxxx4ZNmxYFi1alCR57LHH8uUvfzmjRo3Krrvumj59+uQPf/jDctfz6KOP5mtf+1p5+thjj82hhx5anj7yyCPz5z//OUny0ksv5eijj0737t1z4IEH5r777isvN3DgwAwZMiTf/e5307lz5zz22GN59tlnc8ghh6RLly75wQ9+kIULFy63hkceeSTHHXdcpk+fni5dumTgwIF54403ssMOO+T222/PXnvtlW9961tJkjvuuCP7779/evToke985zt58803y+t5+OGH07dv33Tr1i1Dhw7NUUcdldtvvz1JcvXVV2fAgAHlZZeuf2mwNXfu3JxzzjnZY4890rt371xxxRXlEG3pJV3Dhw9Pjx490qdPn/z1r38tr2v27Nk5++yzs8cee6RHjx75f//v/y2zHZaaNm1aTjnllPTq1St9+vTJLbfcUh576qmn8o1vfCNdu3bNl770pWWCmw/76Dr79OmTG2+8MV/72tfSrVu3Wn/OL730UoYMGZInn3wyXbp0Sffu3ctj7777br73ve+lS5cuOfzww/Paa68t87hjjz02PXv2zH777Zfx48cvt66PatmyZfbbb7+8+OKLHxtr1qxZ9t9//zz//PN1WtdHfXhbHnXUUUmSHj16pEuXLnniiSc+tvyKevjrX/+aAw44IF26dEnv3r1z4403rlZNALC+EkABwKfcddddl3/+858ZM2ZM/vCHP+Tpp5/OtddeWx6fMWNG3nnnnTz00EO55JJLMnjw4Pz3v//92Ho6d+6cV155JbNmzcrixYvzwgsvZPr06Zk3b14WLFiQZ555Jt26dcvixYtz4oknZvfdd88jjzySQYMGZcCAAcusc9y4cTnxxBMzefLk7LLLLvn+97+ffv36ZeLEienbt2/uvffe5fbypS99KT//+c+z+eab54knnsgll1xSHnv88cczfvz43Hjjjfnzn/+cn/3sZ/npT3+av//97+nWrVt++MMfJklmzZqVk08+OT/4wQ/y6KOPZuutt87kyZPr/PMcOHBgGjdunHvvvTd33XVXHn744XJ4lXwQEG233XZ59NFHc/zxx+fcc89NqVRKkpx11ll5//33c/fdd+eRRx7Jt7/97Y+tv6amJieddFJ22GGHPPjgg/m///u//N///V8eeuihJMmwYcNyzDHHZPLkyfnTn/6U/fffv86133PPPbnhhhty33335YUXXsidd975sWW23377XHDBBencuXOeeOKJTJo0qTw2fvz4nHzyyXn88cez9dZbl+8JNX/+/Bx33HE56KCD8sgjj+SKK67IBRdckP/85z8rrWnWrFmZMGFCOnXq9LGx+fPnZ9y4cdl6663r3GNtfvWrXyX54HXyxBNPLHPJal16OPfcc8tnXI0bNy69evX6xDUBwPpEAAUAn3Jjx47N97///bRu3TqtWrXK97///Y+d5XTaaaelqqoqPXv2zJ577pl77rnnY+tp1qxZvvCFL2TSpEn517/+lR133DFdu3bN5MmT8+STT2abbbbJpptumn/+85+ZP39+vve976Wqqiq77bZb9t5779x9993lde2zzz7p1q1bKisr89xzz2Xx4sX51re+lSZNmqRv3775whe+sMp9nnLKKdlwww3TrFmz3Hbbbfne976X7bffPo0bN86JJ56Y5557Lm+++WYefPDBfO5zn0vfvn3TpEmTfOtb38pmm21Wp+eYMWNG/vrXv+acc87JhhtumNatW+fb3/72Mr21b98+//M//5NGjRrlkEMOydtvv50ZM2Zk+vTpefDBB3PBBRdkk002SZMmTdKzZ8+PPcfTTz9dDsmqqqqy1VZb5X/+53/KZ+M0btw4r732WmbNmpXmzZunc+fOdf4ZHX300Wnbtm1atmyZvffeO88991ydH5sk++67b3bZZZc0btw4Bx98cPnxDzzwQDp06JBDDz00jRs3zuc///nst99++eMf/1jrui666KJ07949/fr1S5s2bXL22WeXx37xi1+ke/fu6dq1a/7xj39kxIgRq1Tn6lhZD40bN85//vOfzJs3L5tsskl22mmnwmsCgHWJOywCwKfc9OnT0759+/J0+/btM3369PL0xhtvnA033LDW8Q/r0aNHJk6cmLZt26ZHjx7ZeOON8/jjj5fDq6XPt8UWW6SysnKZdU6bNq083a5du2Xqa9u2bSoqKpZZflVtscUW5f9PmTIlP/7xjzN8+PDyvFKplGnTppXrW6qiomKZelZkypQpWbJkSfbYY4/yvJqammUe/+Ewa4MNNkjywdk1c+bMySabbJJNNtlkhc/x5ptvZvr06ctc+lZdXV2eHjZsWK666qrsv//+2XLLLXPyySdn7733rlP9bdq0Waa22rZzbT7cW7NmzTJ//vxyzU899dTHal7RvccGDRqUww8/fLljxx13XE4//fRMmTIlxx9/fF5++eXsuOOOq1TrqlpZD1dddVWuu+66XHbZZdlhhx3ywx/+8GNnUQHAp5kACgA+5TbffPNMmTIln/vc55IkU6dOzeabb14ef/fddzN//vxyCDV16tTysh/Vs2fPXHLJJWnfvn2++93vZpNNNsl5552XJk2a5H//93/Lz/fWW2+lpqamHEJNnTo122677XLX2aZNm0ybNi2lUqkcQk2ZMiVbbbXVKvX54QCrXbt2OfHEE5cbgLz66qt56623ytOlUilTp04tT2+wwQZZsGBBeXrGjBnl/2+xxRapqqrKo48+usp/SW2LLbbInDlz8u6772bjjTeudbl27dplyy23rPUyxG233TaXX355ampqcu+99+bUU0/NY489tkyI+El9+GdZF+3atUuPHj1y0003rbEakg+CyHPPPTc/+tGPsvfee6dZs2arva6V9bSyHnbZZZdcd911Wbx4cW699db84Ac/WOb+XgDwaecSPAD4lDvwwANz3XXXZdasWZk1a1auueaaZW4mnnxws+ZFixZl0qRJeeCBB9K3b9/lrqtLly55+eWX89RTT2WXXXbJ5z73ufKZIz169EjywRf1Zs2a5YYbbsjixYvz2GOP5f77788BBxyw3HV27tw5jRs3zi233JLFixfn3nvvzdNPP/2Jeu7fv3+uv/768o2t586dW76scM8998yLL76Ye++9N0uWLMktt9yyTMjUqVOnPP7445kyZUrmzp2bn/3sZ+WxzTffPLvvvnsuueSSzJs3LzU1NXnttdcyceLElda0+eab58tf/nIuuOCCzJkzJ4sXL87jjz/+seV22WWXNG/ePNdff30WLFiQ6urq/Pvf/85TTz2VJBkzZkxmzZqVysrKcpD14bPN1oTWrVtn2rRp5ZvVr8xee+2VV155JXfddVcWL16cxYsX56mnnspLL730iWvZfffds/nmm+e3v/3tJ1pPq1atUllZmddff3254yvqYdGiRfnDH/6QuXPnpkmTJmnevPka/5kDwLrOOyMAfMr9v//3/7Lzzjvn4IMPzsEHH5yddtqp/NfXkg8uq9p4443Tu3fvDBgwIOeff36233775a5rww03zE477ZTPfvazqaqqSvJBKNW+ffu0bt06SVJVVZVRo0blwQcfTK9evXLBBRdkxIgRta6zqqoqV199dUaPHp2ePXtm/Pjx+cpXvvKJev7KV76S448/PmeccUa6du2agw46KA8++GCSD4KIK6+8Mpdddll23XXXvPrqq+natWv5sbvvvnsOOOCAHHzwwfnGN77xscvbRowYkcWLF+eAAw5Ijx49cuqpp+btt9+uU10jRoxI48aNs//+++dLX/pS/u///u9jyzRq1CijRo3K888/n3322Se9evXKoEGDMm/evCTJQw89lAMPPDBdunTJsGHDcsUVV3yiM4OWp1evXvnsZz+bPfbYI7vuuutKl2/RokVuvPHGjB8/Pr17984ee+yRSy+9tM4B1socf/zxueGGGz7R+jbYYIOceOKJ+eY3v5nu3bvnySefXGZ8ZT2MGTMmffr0SdeuXXPbbbdl5MiRn6QlAFjvVJSW/tkVAICPeOyxx3LmmWeWw5lPq6OPPjoHH3xwrfckAgBgxZwBBQAAAEChBFAAAAAAFMoleAAAAAAUyhlQAAAAABRKAAUAAABAoQRQAAAAABSqcX0XUJ/eeee91NS4BRYAAADAJ1VZWZFNN22+3LFPdQBVU1MSQAEAAAAUzCV4AAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABSq8dp4knfeeSdnnXVWXnvttVRVVWWbbbbJ0KFD06pVqzz55JMZPHhwFi5cmA4dOmTkyJFp3bp1kqz22OpqtUmzNKpq8on7XZuqFy3OrDkL6rsMAAAAgFpVlEqlUtFPMnv27LzwwgvZddddkyTDhw/PnDlzctFFF2W//fbLxRdfnO7du+faa6/N66+/nosvvjg1NTWrNbYqZs6cl5qa/7/9Nm02ytvX/WqN9l60NicdlbffnlvfZQAAAACfcpWVFWndusXyx9ZGAS1btiyHT0nSuXPnTJkyJc8880yaNm2a7t27J0n69++fP/7xj0my2mMAAAAANCxr5RK8D6upqclvfvOb9OnTJ1OnTk379u3LY61atUpNTU1mz5692mMtW7ascy21pXLrmjZtNqrvEgAAAABqtdYDqAsvvDAbbrhhjjrqqPzpT39a20+/jOVdgrcucgkeAAAAUN9WdAneWg2ghg8fnldffTWjRo1KZWVl2rVrlylTppTHZ82alcrKyrRs2XK1xwAAAABoWNbKPaCS5PLLL88zzzyTa665JlVVVUmSnXfeOQsWLMikSZOSJLfddlv69u37icYAAAAAaFjWyl/Be/HFF3PQQQdl2223TbNmzZIkW265Za655ppMnjw5Q4YMycKFC9OhQ4eMHDkym222WZKs9lhd+St4AAAAAGvGii7BWysBVEMlgAIAAABYM1YUQK21S/AAAAAA+HQSQAEAAABQKAEUAAAAAIUSQAEAAABQKAEUAAAAAIUSQAEAAABQKAEUAAAAAIUSQAEAAABQKAEUAAAAAIUSQAEAAABQKAEUAAAAAIVqXN8FsPa02qRpGlVV1XcZq6R60aLMmrOwvssAAAAAPgEB1KdIo6qqvHXdRfVdxirZ4qRBSQRQAAAAsC5zCR4AAAAAhRJAAQAAAFAoARQAAAAAhRJAAQAAAFAoARQAAAAAhRJAAQAAAFAoARQAAAAAhRJAAQAAAFAoARQAAAAAhRJAAQAAAFAoARQAAAAAhRJAAQAAAFAoARQAAAAAhRJAAQAAAFAoARQAAAAAhWpc3wXAmrLpJlVpXNW0vstYJUsWLcw7cxbVdxkAAABQKAEU643GVU3z/DX96ruMVbLj98ckEUABAACwfnMJHgAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUCgBFAAAAACFEkABAAAAUKjG9V0AUDebblKVxlVN67uMOluyaGHembOovssAAACgARBAwTqicVXTPPDzA+u7jDrb67t3JxFAAQAA4BI8AAAAAAq21s6AGj58eCZMmJA333wzY8eOTceOHfPGG2/k+9//fnmZuXPnZt68eZk4cWKSpE+fPqmqqkrTph9cdjRgwID07t07SfLkk09m8ODBWbhwYTp06JCRI0emdevWa6sdAAAAAOporQVQ++yzT4455pj87//+b3nelltumTFjxpSnhw0blurq6mUed9VVV6Vjx47LzKupqcmZZ56Ziy++ON27d8+1116bSy+9NBdffHGxTQAAAACwytbaJXjdu3dPu3btah1ftGhRxo4dm0MPPXSl63rmmWfStGnTdO/ePUnSv3///PGPf1xjtQIAAACw5jSYm5Dff//9adu2bXbaaadl5g8YMCClUindunXLGWeckY033jhTp05N+/bty8u0atUqNTU1mT17dlq2bFnn52zdusWaKr9etWmzUX2XUCj9rbvW594AAACouwYTQP3+97//2NlPt956a9q1a5dFixZl2LBhGTp0aC699NI19pwzZ85LTU2pPL2ufll+++25dVpOfw3T+txfXXsDAABg3VdZWVHryT4N4q/gTZs2LY8//ni+9rWvLTN/6SV7VVVVOfLIIzN58uTy/ClTppSXmzVrViorK1fp7CcAAAAA1o4GEUCNHj06e+65ZzbddNPyvPnz52fu3A/OniiVShk/fnw6deqUJNl5552zYMGCTJo0KUly2223pW/fvmu/cAAAAABWaq1dgnfRRRfl3nvvzYwZM3LsscemZcuWufvuu5N8EECde+65yyw/c+bMnHLKKamurk5NTU223377DBkyJElSWVmZESNGZMiQIVm4cGE6dOiQkSNHrq1WAAAAAFgFay2AGjRoUAYNGrTcsQkTJnxs3lZbbZW77rqr1vV17do1Y8eOXVPlAQAAAFCQBnEJHgAAAADrLwEUAAAAAIUSQAEAAABQKAEUAAAAAIUSQAEAAABQKAEUAAAAAIUSQAEAAABQKAEUAAAAAIUSQAEAAABQKAEUAAAAAIUSQAEAAABQKAEUAAAAAIUSQAEAAABQKAEUAAAAAIUSQAEAAABQKAEUAAAAAIUSQAEAAABQKAEUAAAAAIVqXN8FALTcpCpNqprWdxmrZPGihZk9Z1F9lwEAALBOEEAB9a5JVdPccVPf+i5jlRx27B+TCKAAAADqwiV4AAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRqrQVQw4cPT58+fbLDDjvk3//+d3l+nz590rdv3/Tr1y/9+vXLQw89VB578sknc/DBB2e//fbLcccdl5kzZ9ZpDAAAAICGY60FUPvss09uvfXWdOjQ4WNjV111VcaMGZMxY8akd+/eSZKampqceeaZGTx4cCZMmJDu3bvn0ksvXekYAAAAAA3LWgugunfvnnbt2tV5+WeeeSZNmzZN9+7dkyT9+/fPH//4x5WOAQAAANCwNK7vApJkwIABKZVK6datW84444xsvPHGmTp1atq3b19eplWrVqmpqcns2bNXONayZct66AAAAACA2tR7AHXrrbemXbt2WbRoUYYNG5ahQ4eutcvpWrdusVaep2ht2mxU3yUUSn/rrvW5t2T97w8AAGBNqfcAaulleVVVVTnyyCNz0kknledPmTKlvNysWbNSWVmZli1brnBsVcycOS81NaXy9Lr6ZfLtt+fWaTn9NUzrc3/rc29J3fsDAAD4NKisrKj1ZJ+1dg+o5Zk/f37mzv3gC1ypVMr48ePTqVOnJMnOO++cBQsWZNKkSUmS2267LX379l3pGAAAAAANy1o7A+qiiy7KvffemxkzZuTYY49Ny5YtM2rUqJxyyimprq5OTU1Ntt9++wwZMiRJUllZmREjRmTIkCFZuHBhOnTokJEjR650DAAAAICGZa0FUIMGDcqgQYM+Nv+uu+6q9TFdu3bN2LFjV3kMAAAAgIajXi/BAwAAAGD9J4ACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAK1XhtPdHw4cMzYcKEvPnmmxk7dmw6duyYd955J2eddVZee+21VFVVZZtttsnQoUPTqlWrJMkOO+yQjh07prLyg5xsxIgR2WGHHZIk999/f0aMGJHq6urstNNOufjii7PBBhusrXYAAAAAqKO1dgbUPvvsk1tvvTUdOnQoz6uoqMjxxx+fCRMmZOzYsdlqq61y6aWXLvO42267LWPGjMmYMWPK4dN7772X8847L6NGjcqf/vSnNG/ePDfeeOPaagUAAACAVbDWAqju3bunXbt2y8xr2bJldt111/J0586dM2XKlJWu68EHH8zOO++cbbfdNknSv3//3HPPPWu0XgAAAADWjLV2Cd7K1NTU5De/+U369OmzzPyjjz461dXV+fKXv5xTTjklVVVVmTp1atq3b19epn379pk6deraLhkAAACAOmgwAdSFF16YDTfcMEcddVR53gMPPJB27dpl3rx5OfPMM3PNNdfk9NNPX2PP2bp1izW2rvrUps1G9V1CofS37lqfe0vW//4AAADWlAYRQA0fPjyvvvpqRo0aVb7heJLyJXstWrTI4Ycfnptuuqk8/7HHHisvN2XKlI9d3lcXM2fOS01NqTy9rn6ZfPvtuXVaTn8N0/rc3/rcW1L3/gAAAD4NKisraj3ZZ63dA6o2l19+eZ555plcc801qaqqKs+fM2dOFixYkCRZsmRJJkyYkE6dOiVJevfunaeffjqvvPJKkg9uVL7//vuv9doBAAAAWLm1dgbURRddlHvvvTczZszIsccem5YtW+YnP/lJfvazn2XbbbdN//79kyRbbrllrrnmmvz3v//N4MGDU1FRkSVLlqRLly457bTTknxwRtTQoUNzwgknpKamJp06dcq55567tloBAAAAYBWstQBq0KBBGTRo0Mfmv/DCC8tdvkuXLhk7dmyt69t3332z7777rrH6AAAAAChGvV+CBwAAAMD6TQAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKHqHEDdeOONy51/0003rbFiAAAAAFj/1DmAuuaaa5Y7/7rrrltjxQAAAACw/mm8sgX+/ve/J0lqamry6KOPplQqlcfeeOONNG/evLjqAAAAAFjnrTSAOvfcc5MkCxcuzDnnnFOeX1FRkTZt2mTQoEHFVQcAAADAOm+lAdT999+fJDnrrLMyYsSIwgsCAAAAYP2y0gBqqQ+HTzU1NcuMVVb6Y3oAAAAALF+dA6h//etfGTp0aF544YUsXLgwSVIqlVJRUZHnnnuusAIBAAAAWLfVOYAaOHBg9t577/z4xz9Os2bNiqwJAAAAgPVInQOoN998M6effnoqKiqKrAcAAACA9Uydb970la98JX/729+KrAUAAACA9VCdz4BauHBhTj755HTr1i2bbbbZMmP+Oh4AAAAAtalzAPXZz342n/3sZ4usBQAAAID1UJ0DqJNPPrnIOgAAAABYT9U5gPr73/9e69huu+22RooBAAAAYP1T5wDq3HPPXWb6nXfeyeLFi9O2bdvcd999a7wwAAAAANYPdQ6g7r///mWmq6urc91116V58+ZrvCgAAAAA1h+Vq/vARo0a5cQTT8wNN9ywJusBAAAAYD2z2gFUkjz88MOpqKhYU7UAAAAAsB6q8yV4e+655zJh0/vvv59FixZlyJAhhRQGAAAAwPqhzgHUyJEjl5neYIMNst1226VFixZrvCgAAAAA1h91DqB69uyZJKmpqcmMGTOy2WabpbLyE13BBwAAAMCnQJ0TpHnz5uWss87KLrvski9/+cvZZZdd8qMf/Shz584tsj4AAAAA1nF1DqAuuuiivP/++xk7dmyeeuqpjB07Nu+//34uuuiiIusDAAAAYB1X50vwHnroofz5z3/OBhtskCTZbrvtcvHFF+crX/lKYcUBAAAAsO6rcwDVtGnTzJo1Kx06dCjPe+edd1JVVVVIYQDri01aNklVk2b1XcYqWbR4QebMXlzfZQAAAOuJOgdQhx12WI477rh8+9vfTvv27TNlypTcfPPNOfzww4usD2CdV9WkWX72y/3qu4xVcsLRE5IIoAAAgDWjzgHUSSedlLZt22bs2LGZPn16Nt988xx//PF1CqCGDx+eCRMm5M0338zYsWPTsWPHJMnLL7+cgQMHZvbs2WnZsmWGDx+ebbfd9hONAQAAANCw1Pkm5MOGDct2222Xm2++OePHj8/NN9+c7bffPsOGDVvpY/fZZ5/ceuuty1y+lyRDhgzJkUcemQkTJuTII4/M4MGDP/EYAAAAAA1LnQOocePGZeedd15m3s4775xx48at9LHdu3dPu3btlpk3c+bMPPvssznooIOSJAcddFCeffbZzJo1a7XHAAAAAGh46nwJXkVFRWpqapaZV11d/bF5dTV16tS0bds2jRo1SpI0atQom2++eaZOnZpSqbRaY61atVqlGlq3brFatTc0bdpsVN8lFEp/6671ubdEfwAAAHVV5wCqe/fuufLKK3PmmWemsrIyNTU1ufrqq9O9e/ci6yvUzJnzUlNTKk+vq1+23n57bp2W01/DtD73tz73lugPAADgwyorK2o92afOAdS5556bE044IXvssUfat2+fqVOnpk2bNhk1atRqFdWuXbtMmzYt1dXVadSoUaqrqzN9+vS0a9cupVJptcYAAAAAaHjqHEBtscUWGT16dJ566qlMnTo17dq1yy677JLKyjrfRmoZrVu3TqdOnTJu3Lj069cv48aNS6dOncqX0a3uGAAAAAANS50DqCSprKxM586d07lz51V6kosuuij33ntvZsyYkWOPPTYtW7bM3XffnfPPPz8DBw7Mtddem4033jjDhw8vP2Z1xwAAAABoWFYpgFpdgwYNyqBBgz42f/vtt8/tt9++3Mes7hgAAAAADcvqXT8HAAAAAHUkgAIAAACgUAIoAAAAAAolgAIAAACgUAIoAAAAAAolgAIAAACgUI3ruwAA1m2btGySqibN6ruMVbJo8YLMmb24vssAAIBPDQEUAJ9IVZNmOf93+9V3Gavk/P+ZkEQABQAAa4tL8AAAAAAolAAKAAAAgEIJoAAAAAAolHtAAcAKbNSyKs2aNK3vMlbJgsULM3f2ovouAwAAygRQALACzZo0zf5jDq3vMlbJPf1+n7kRQAEA0HC4BA8AAACAQgmgAAAAACiUAAoAAACAQgmgAAAAACiUAAoAAACAQgmgAAAAACiUAAoAAACAQgmgAAAAACiUAAoAAACAQgmgAAAAACiUAAoAAACAQgmgAAAAACiUAAoAAACAQgmgAAAAACiUAAoAAACAQgmgAAAAACiUAAoAAACAQjWu7wIAgPqzUcumadakqr7LqLMFixdl7uyF9V0GAACrSAAFAJ9izZpU5YDRF9V3GXU2/pBBmRsBFADAusYleAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUAAAAAAUqnF9FwAAUISNWjZLsyZN6ruMVbJg8eLMnb2gvssAAFjjBFAAwHqpWZMmOfDO6+q7jFVy9zdOytwIoACA9Y8ACgBgHeQMLwBgXSKAAgBYBzVr0iQH3XFrfZexSsYd9r/O8AKATyk3IQcAAACgUAIoAAAAAAolgAIAAACgUAIoAAAAAArlJuQAADQ4G7XcIM2arFsfVRcsXpK5s9+v7zIAoEFat97VAQD4VGjWpHEOvmNsfZexSv5w2Ncyt76LAIAGyiV4AAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoQRQAAAAABRKAAUAAABAoRrXdwFvvPFGvv/975en586dm3nz5mXixInp06dPqqqq0rRp0yTJgAED0rt37yTJk08+mcGDB2fhwoXp0KFDRo4cmdatW9dLDwAAAADUrt4DqC233DJjxowpTw8bNizV1dXl6auuuiodO3Zc5jE1NTU588wzc/HFF6d79+659tprc+mll+biiy9ea3UDAAAAUDf1HkB92KJFizJ27NjceOONK1zumWeeSdOmTdO9e/ckSf/+/bPPPvsIoAAAWCds1HKDNGvSoD6Kr9SCxUsyd/b79V0GAOuoBvWud//996dt27bZaaedyvMGDBiQUqmUbt265YwzzsjGG2+cqVOnpn379uVlWrVqlZqamsyePTstW7ash8oBAKDumjVpnEN+/7f6LmOVjD50j8yt7yIAWGc1qADq97//fQ499NDy9K233pp27dpl0aJFGTZsWIYOHZpLL710jT1f69Yt1ti66lObNhvVdwmF0t+6a33uLdHfuk5/6671ubdEf+s6/QHA8jWYAGratGl5/PHHM2LEiPK8du3aJUmqqqpy5JFH5qSTTirPnzJlSnm5WbNmpbKycpXPfpo5c15qakrl6XX1DfXtt+v2uyj9NUzrc3/rc2+J/pbSX8O0Pve3PveW6G8p/TVMde0PgE+nysqKWk/2qVzLtdRq9OjR2XPPPbPpppsmSebPn5+5cz94gyuVShk/fnw6deqUJNl5552zYMGCTJo0KUly2223pW/fvvVTOAAAAAAr1GDOgBo9enTOPffc8vTMmTNzyimnpLq6OjU1Ndl+++0zZMiQJEllZWVGjBiRIUOGZOHChenQoUNGjhxZX6UDAAAAsAINJoCaMGHCMtNbbbVV7rrrrlqX79q1a8aOHVtwVQAAAAB8Ug3mEjwAAAAA1k8CKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAK1bi+CwAAANYvG7XcMM2aNKrvMupsweLqzJ09v77LAFivCaAAAIA1qlmTRjnizv/Udxl19ttvfDZz67sIgPWcS/AAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCNa7vAgAAANYVm7Rsnqom69bv8Rctrsmc2e/VdxnAp5wACgAAoI6qmlTmmtHT6ruMVfL9Q9rWdwkALsEDAAAAoFgCKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFACKAAAAAAKJYACAAAAoFCN67uAJOnTp0+qqqrStGnTJMmAAQPSu3fvPPnkkxk8eHAWLlyYDh06ZOTIkWndunWSrHAMAAAAgIajwZwBddVVV2XMmDEZM2ZMevfunZqampx55pkZPHhwJkyYkO7du+fSSy9NkhWOAQAAANCwNIgzoJbnmWeeSdOmTdO9e/ckSf/+/bPPPvvk4osvXuEYAAAAq6dly+Zp0qTBnKdQJ4sX12T27PfquwxgJRpMADVgwICUSqV069YtZ5xxRqZOnZr27duXx1u1apWamprMnj17hWMtW7ash+oBAADWfU2aVOae386o7zJWyf5HbFbfJQB10CACqFtvvTXt2rXLokWLMmzYsAwdOjRf+cpXCn/e1q1bFP4ca0ObNhvVdwmF0t+6a33uLdHfuk5/6671ubdEf+s6/a271ufeEv0tVbOklMrGFQVXs2atSs2lJaVUrGP9rYs1s3oaRADVrl27JElVVVWOPPLInHTSSTnmmGMyZcqU8jKzZs1KZWVlWrZsmXbt2tU6tipmzpyXmppSeXpdPSi//fbcOi2nv4Zpfe5vfe4t0d9S+muY1uf+1ufeEv0tpb+GaX3ub33uLdHfUm3abJQnbphecDVrVpfjN1+l/qaOeLPgitasdmd1qHN/NHyVlRW1nuxT7xf3zp8/P3PnfvBiK5VKGT9+fDp16pSdd945CxYsyKRJk5Ikt912W/r27ZskKxwDAAAAoGGp9zOgZs6cmVNOOSXV1dWpqanJ9ttvnyFDhqSysjIjRozIkCFDsnDhwnTo0CEjR45MkhWOAQAAAOufVptsmEZVjeq7jDqrXlSdWXPm13cZDUa9B1BbbbVV7rrrruWOde3aNWPHjl3lMQAAAGD90qiqUab95B/1XUadtf1Bt/ouoUGp90vwAAAAAFi/CaAAAAAAKJQACgAAAIBCCaAAAAAAKFS934QcAAAA4NOs1SYbpFHVuhXRVC9akllz3q/z8utWdwAAAADrmUZVjTP9p/fWdxmrZPOTv7pKy7sEDwAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKJQACgAAAIBCCaAAAAAAKFTj+i7gnXfeyVlnnZXXXnstVVVV2WabbTJ06NC0atUqO+ywQzp27JjKyg9yshEjRmSHHXZIktx///0ZMWJEqqurs9NOO+Xiiy/OBhtsUJ+tAAAAALAc9X4GVEVFRY4//vhMmDAhY8eOzVZbbZVLL720PH7bbbdlzJgxGTNmTDl8eu+993Leeedl1KhR+dOf/pTmzZvnxhtvrK8WAAAAAFiBeg+gWrZsmV133bU83blz50yZMmWFj3nwwQez8847Z9ttt02S9O/fP/fcc0+RZQIAAACwmur9ErwPq6mpyW9+85v06dOnPO/oo49OdXV1vvzlL+eUU05JVVVVpk6dmvbt25eXad++faZOnbrKz9e6dYs1Und9a9Nmo/ouoVD6W3etz70l+lvX6W/dtT73luhvXae/ddf63Fuiv3Wd/tZd63Nvyar116ACqAsvvDAbbrhhjjrqqCTJAw88kHbt2mXevHk588wzc8011+T0009fY883c+a81NSUytPr6gvj7bfn1mk5/TVM63N/63Nvif6W0l/DtD73tz73luhvKf01TOtzf+tzb4n+ltJfw7Q+97c+95Z8vL/KyopaT/ap90vwlho+fHheffXV/OQnPynfdLxdu3ZJkhYtWuTwww/P5MmTy/M/fJnelClTyssCAAAA0LA0iADq8ssvzzPPPJNrrrkmVVVVSZI5c+ZkwYIFSZIlS5ZkwoQJ6dSpU5Kkd+/eefrpp/PKK68k+eBG5fvvv3+91A4AAADAitX7JXgvvvhifvazn2XbbbdN//79kyRbbrlljj/++AwePDgVFRVZsmRJunTpktNOOy3JB2dEDR06NCeccEJqamrSqVOnnHvuufXZBgAAAAC1qPcA6nOf+1xeeOGF5Y6NHTu21sftu+++2XfffYsqCwAAAIA1pEFcggcAAADA+ksABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFEoABQAAAEChBFAAAAAAFGqdDqBefvnlHHHEEdlvv/1yxBFH5JVXXqnvkgAAAAD4iHU6gBoyZEiOPPLITJgwIUceeWQGDx5c3yUBAAAA8BGN67uA1TVz5sw8++yzuemmm5IkBx10UC688MLMmjUrrVq1qtM6KisrPj5vo+ZrtM61YXl91KbRRpsUWEkxVqW/JhttXmAlxViV/pq1WLf6W5XeNmzRtsBKirEq/bVovn7313LD9bu/zTdoU2AlxVil/jZct94bVq23jQqspBir1t/6/bll8w03KLCSYqxKf202bFpgJcVYtf7Wra8aq9LbRhuue7/HX5X+NljP+6tqsX7312jjRgVWUoxV6a9y46oCK1nzVqm3jZoVWEkxPtrfivqtKJVKpaILKsIzzzyTH/3oR7n77rvL8w444ICMHDkyO+20Uz1WBgAAAMCHrXvRLwAAAADrlHU2gGrXrl2mTZuW6urqJEl1dXWmT5+edu3a1XNlAAAAAHzYOhtAtW7dOp06dcq4ceOSJOPGjUunTp3qfP8nAAAAANaOdfYeUEny0ksvZeDAgXn33Xez8cYbZ/jw4fnMZz5T32UBAAAA8CHrdAAFAAAAQMO3zl6CBwAAAMC6QQAFAAAAQKEEUAAAAAAUSgAFAAAAQKEEUGvJY489lm984xurPNbQ/PnPf87++++fr3/969lll12yYMGC+i5pjXnuuecyfvz4+i5jjbr66quzaNGient8kXbYYYe899579V3GGrU+b69Pg9V5TU6bNi1HH310ndbRp0+f/Pvf//5ENa6Kfv36rVfHeOrmjTfeyK677rrS5dbH98xPi4EDB+ZXv/rVcseuvPLK8nZdtGhRvvvd7+ZrX/tafvzjH+fOO+/Myy+/XHh9Rx99dP7yl78U/jwN1afl2Hv11Vdn+PDh9V3GCt18882ZOXPmGl/vivbBFamPfePll1/O0Ucfnb59++aggw7K2Wefvc6+Pj/8nbuu73WseQIoVsltt92WU089NXfddVeeeuqpNGvWrL5LWmOee+65/PGPf6x1fMmSJWuxmjXjpz/9aRYvXlxvj2fV2F6fPm3bts0vf/nL+i5jucaMGbNeHeM/bF08njc0K3vPZN102mmn5YADDkjywTaeMmVKxo4dm3POOSejR4/OK6+88omfw/63YuvzsXddc8sttxQSQK1LmjRpkrPPPjt//OMf84c//CHvv/9+brzxxvoui3VY4/ouYH3wwx/+MC+//HIWL16crbfeOj/+8Y+zySab5Iorrsj48eOz8cYbp2fPnss8ZkVjDdWPf/zj/OMf/8jLL7+cX//615k4cWImT56cBQsW5PDDD8+VV16ZL3zhCxk9enR+97vf5Ze//GUaNy72JfbGG2/k0EMPzWOPPbbM9O9///sceuihOeSQQ/Lwww8nSYYMGZLu3btn5syZ+eEPf1h+Q9ltt91y0kkn5aqrrsq8efPSr1+/9OjRI4MGDcoOO+yQk08+OQ888EB69+6d448/PhdffHFeeOGFLFy4MLvuumvOPvvsNGrUKL/4xS9y9913p7q6Ok2bNs3555+fTp06JfngrIYf/OAH+fOf/5zZs2fnoosuyiOPPJKHHnooS5YsyZVXXpntt99+jf5sLrjggiRJ//79U1lZmeuuuy7XXHPNcmv/6U9/mnHjxqVp06apqKjILbfckiuuuGKZx//yl7/MxhtvvEZr/KRuvPHG3HfffVmwYEHOOOOM7LfffrW+JpZO/+pXv8ott9ySjTbaKHvuuWduvfXW8lh9KmJ73XPPPbn55ptTVVWVmpqa/OQnP1njr7NPorZtNX78+I/to+ecc06S5Prrr8+9996b6urqtG3bNhdeeGHatGlTbz181Kq+Jj869mGTJk0qvy569OiRUqm0VnvZYYcdMnny5DRv3jx9+vTJ1772tTz66KOZNm1aefuMGzcuc+bMyY9//OP06NEjS5YsyQknnJB33nknCxcuzC677JILLrggVVVVWbRoUS688MJMnDgxrVq1SqdOnTJjxoxcddVVSYrftqtyPD/66KOz00475amnnsqbb76ZY445Jm3bts2vfvWrTJ8+PWeeeWb233//JMmDDz6Yyy+/PNXV1WnVqlWGDh2abbbZJt/+9rdz1FFHZd99902S/OUvf8kvfvGL/PKXv8z06dNz0UUXZcqUKVm4cGEOPPDAnHjiiZ+4x9V5T0ySW2+9NTfffHNatGiRPffcs7y+2rbne++9t9z3zH/+85+59NJLy2fxnXrqqdlrr70+cV+fVG3b6I477sgtt9yS5IMvWT/72c+y2Wab1Us9b731VoYNG5Ydd9wx//rXv7LBBhvkkksuyWc/+9kkyejRo/PrX/861dXVadGiRc4///x85jOfyZ133plx48Zl4403zosvvpiNNtooV199ddq0aZPJkyfnwgsvTE1NTZYsWZKTTjopBx10UJLk3//+d4455pi89dZb6dy5c4YPH56KiooMHDgwO++8c770pS9lwIABmT59evr165cDDzwwzzzzTC666KL85Cc/yY9+9KN86UtfqnPPq7L/fdi8efNW+XPX+++/nx/96Ef5z3/+k8aNG2e77bbLlVdeucKf49py22235YUXXsiQIUPy1FNP5fDDD8/tt9+eXXbZpVz/4MGDlzn2HnDAAXnkkUcyd+7cfOtb38pRRx211uqtTV0/17799ts544wz8t5772XhwoXZc889c9ZZZ31sfS+88EIGDBiQ8847L507d84VV1yRxx9/PIsWLcoOO+yQ888/P82bN//EdS/vGPXss8/m2WefzU9/+tO8//77+Z//+Z8MGDAgzz77bKZPn55TTz01TZs2zWWXXZatt9661toGDhyYqqqqvPLKKx/br6ZNm5azzjorb7/9djp06JDKyv//HJAVvcb/85//5Oyzz878+fPTsWPHLFy48BP/DFb15/PhY3hlZWV22WWXvPTSS+V59b1P1WZ5389XpLb3iTPOOCNf+cpXsv/+++fnP/95Ro0alYkTJ6ZRo0Y54IADcs0112S77bZbS1193A477JDTTz89f/rTnzJ79uycddZZ2W+//ZLUvj0vu+yybLLJJjn++OMzfvz4nHHGGXn44YfTunXrfPe73823vvWt7LHHHsUVXeITmzlzZvn/l19+eWnkyJGl++67r3TQQQeV5s2bV1qyZEnphBNOKB1yyCGlUqm0wrGG7qijjirdf//9pVKpVOrYsWNp3rx5pVKpVHr00UdLX/3qV0tPPPFEaa+99ipNmTJlrdTz+uuvl3r27Pmx6ddff73UsWPH0ujRo8v19e7du7Rw4cLSTTfdVDrvvPPKj5k9e3apVCqVfv/735dOOeWUZdbfsWPH0s9+9rPy9DnnnFNeZ3V1den0008v/fa3vy2VSsu+Dh5++OHS4Ycfvsx6fvWrX5VKpVJp/Pjxpc6dO5d/jtdff33phz/84Sf9USzXh7dRbbW/8847pW7dupXef//9UqlUKs2dO7e0ePHijz2+oenYsWPp6quvLpVKpdJLL71U6tmzZ2nGjBm1viZKpVLpueeeK+2xxx7lbXXhhRcus2x9W9Pbq2vXrqVp06aVSqVSaeHChaX58+evxW5WrrZtVds+etddd5UGDRpUqq6uLpVKpdKtt95aOuOMM9Zu0SuwOq/Jj44t3YYLFy4s7bHHHqVHH320VCqVSnfffXepY8eOpRdeeGGt9rP09bT33nuXLrnkklKpVCr985//LH3xi18sH9PuvvvuUv/+/UulUqlUU1NTmjVrVvn/Z555ZunXv/51qVQqlW655ZbScccdV1q8eHFpwYIFpcMPP7x8zF0b23ZVjudHHXVU6bTTTitVV1eX3nrrrdIuu+xSuvzyy8v99+7du1QqlUozZswo7brrrqUXX3yxVCqVSr/73e9Khx12WLmn73//++XnO/nkk8vP9+1vf7s0ceLEUqn0wb75zW9+s/S3v/3tE/e4Ou+Jzz33XGn33Xcvvf3226VSqVQaMmRIeR0r2p4ffc+cM2dOqV+/fuVjzrRp00q9e/cuzZkz5xP39UnUto0effTR0r777luaPn16qVQqlebNm1dasGBBvdbTsWPH0mOPPVYqlUqlO++8s/zZ8PHHHy9997vfLS1cuLBUKpVKDzzwQOmII44olUofbIfu3buXP3ede+655dfqiSeeWBo7dmypVPpg+y3dFj/60Y9K/fv3Ly1YsKC0cOHC0gEHHFB+/f3oRz8q/fKXvyyVSh+8Tj78+fTDnwFX1aruf0ufZ3U+d917772l4447rjy29D1kRT/HteWVV14p7bfffqVSqVQaNWpU6Ygjjij/XL761a+WXn311Y8dewcOHFgqlUqlt99+u7T77ruXnnvuubVa8/LU9XPtggULyr0sWrSodPTRR5f++te/lkqlUumqq64qXXLJJaWHH364dNBBB5X3iWuuuaZ0zTXXlJ9rxIgR5df0J1HbMeqdd94pHXvssaVbbrmlNHDgwNLw4cPLj9l7772Xed9dUW0r2q9OPvnk8ueD1157rdS5c+fyfrai1/ghhxxSuvPOO0ulUqn0xBNPlHbcccfV3gdXpi7H8Pfff790wAEHlP785z+XSqWGsU/VZnnfzz98TPvw++WK3st/97vflT+THnfccaUjjjii9MQTT5SmTZtW2nPPPddiR8vXsWPH8mtp0qRJpT322KNUKq14ez788MPlY+R5551XOuKII0rjxo0rLVq0qNSzZ8/Cvy84A2oNGDNmTMaOHZvFixdn/vz52XbbbbN48eIccMAB5bT+sMMOy7XXXpvkg+tPaxtbV+2666456KCDcuSRR+anP/1p2rVrV98lpUmTJjn44IOTfFBfs2bN8t///jdf/OIXc/PNN2f48OHp2bPnShPeQw45pPz/+++/P0899VRuuummJMmCBQvStm3bJMkzzzyTn/3sZ5kzZ04qKio+dpr60t+W77TTTkmSvffeO0my8847509/+tMnb3glaqt9o402ytZbb52zzjore+yxR/baa6+0aNGi8HrWhMMPPzxJ8pnPfCaf//zn8+STT2aHHXaodfmJEydmzz33TKtWrZJ8sO+NHTt2rdS6qtbE9urVq1cGDhyYvffeO3vttVe22mqrtdnCaqttH73//vvzzDPPlPfJpb9ta0hW9TVZm//+97/ZYIMNyvcnOOCAAzJ48OA1WuuqWnpZzk477ZT333+/fEzbeeed89prryVJampq8otf/CIPPvhgampqMmfOnPKlJI899lj69euXxo0bp3HjxjnwwAPzj3/8I8na27Z1PZ4nSd++fVNZWZm2bdumZcuW5TOZdtppp0ybNi0LFy7MP//5z+y4447ls1QOPfTQXHDBBZk3b16++tWv5uKLL84777yT5IPjz/DhwzN//vxMnDgxs2bNKj/Xe++9l5deeim77777Gu95qdreEydOnJi99tqrfObPEUcckXvuuSfJirfnRz3xxBN544038t3vfrc8r6KiIq+++mq+8IUvFNbXytS2je67777069evfJbdmji74pPU895772WbbbYpnxXfr1+/nHfeeZk3b17uv//+PP/88+XjS6lUyrvvvlteZ9euXcufu774xS/mkUceSfLBdr7uuuvy2muvZffdd88Xv/jF8mP23XffNG3aNEny+c9/vrxMkVZl/6vLcrV97tpxxx3z0ksv5YILLkjPnj3LZ3Cs7Oe4NmyzzTZZuHBh3nrrrfz973/P6aefnlGjRuVrX/ta+UyNjzrssMOSJJtttln22muvTJw4MTvuuONarXt56vK5trq6OiNGjMgTTzyRUqmUGTNm5Pnnn8+Xv/zlJMnf/va3PPTQQ7nxxhvL2/X+++/PvHnzMmHChCQf3ItsTfRb2zHq9ddfz8iRI9OvX7+0b98+v/71r2tdx8pqq22/euyxxzJo0KAkyVZbbZXddtttmXUu7zU+b968/Pvf/06/fv2SJJ07d07Hjh0/8c+hNis7hi9ZsiSnn356evXqlX322adce33vU7VZ3vfz3r17L3fZFb2X9+rVK9dff30WLVqUt956K9/5znfyyCOPpH379g3mHlJLP5917tw506dPz8KFC1e4Pbt27ZrTTz89ixYtyuTJk3PWWWdlwoQJadu2bT73uc9lgw02KLReAdQnNGnSpPzmN7/JbbfdllatWmXs2LH53e9+V99l1Ytnn302rVq1yltvvbXWnrNx48bLXJZSl1NTu3TpktGjR+eRRx7JmDFjcv311+c3v/lNrctvuOGG5f+XSqVce+21H/siv2jRopx22mn51a9+Vf5ysvTNdamlb0iVlZWpqqoqz6+srFwr90OorfYk+d3vfpfJkyfn0UcfzTe+8Y3ccMMNDeLDzepYnddEQ7QmttdPf/rTPP3003n00UdzzDHH5Pzzz1/m8pr6Vtu2qm0fLZVKOemkk8ofxtcVa+o1WVFRsaZKWi1Lj2FLL5H58DFt6TFs7Nix+cc//pFbb701LVq0yKhRo+p0z5i1tW3rcjxfaml/yQc9f7T/lR23N9hgg+yzzz4ZN25ckmSfffbJhhtumHnz5qWioiJ33HFHmjRp8on6+ag1ffxble1ZKpWyww475NZbb/1Ez8nHlUqlHHrooTnttNOWO/7R12p1dXWS5Nvf/nb69OmTRx55JBdeeGF23333nH766St8TJFWZf9b2XIr+ty11VZbZdy4cXn00Ufz4IMP5oorrsjYsWNX+nNcW3r16pW//OUvmTlzZnbddddceOGFeeCBBxrMl9m6qsvn2ptuuinvvvtubr/99jRt2jTnnXfeMsel7bbbLi+++GKeeeaZcgBVKpUyZMiQZUKaNWFFx6h//vOfqayszLvvvpsFCxbU+guQldW2OvtVba/xefPmrfSxa9KKfj7V1dUZMGBANtlkk3KQtvQxDWGf+qg1+f18q622Sk1NTe6+++507tw5u+22W84666x06NBhjb9GV9fyPp+s7D25Y8eOufvuu9OmTZv06tUrw4cPzxZbbJFevXoVXq+bkH9C7777blq0aJGWLVtm0aJF+f3vf5/kgzeXe+65J/Pnz091dXV5/srG1lU333xzlixZkjvvvDM33HBDnnvuubXyvJtttlkWL16cV199NUnKH/STZPHixeWzWyZNmpQFCxbkM5/5TF5//fW0aNEiBx54YM4+++z861//Sk1NTVq0aJG5c+eu8Pn69OmT66+/vvyGMmvWrLz++utZtGhRlixZUv4N5Ip+e7I2NW/evPwGVlvt8+bNy6xZs9KzZ8+ceuqp6dixY1588cWPPb4hWrrvvPLKK3n22WfTuXPnFb4mevbsmQcffLB85sHo0aPXftErsCa315IlS/L6669nl112yfe+973svvvua22/rKvatlVt+2ifPn3y61//OnPmzEnywReQ559/vt7qX55VfU3W5jOf+UwWLFiQSZMmJUn++Mc/NpjfKq7I3Llzs+mmm5aPpx/d/8aOHZslS5Zk4cKF5bNsktTLtq1tH1sVnTt3zvPPP1++H8bo0aPz+c9/vvzl5ZBDDsno0aMzevTo8l/eadGiRbp165brr7++vJ6pU6fm7bff/sQ9rc57Ys+ePfPXv/61fM+1O+64o/yYFW3Pj75ndunSJa+++moeffTR8rynnnpqrd+77KNq20b77LNPxowZkxkzZiRJ+R419VVP8+bN89prr5X3+bFjx6Zjx45p0aJF+vTpkzFjxpR/wVddXZ1nnnlmpc/18ssvZ+utt07//v1zzDHH5Omnn/5EtTdv3nyln5Pqqq773+p87nrrrbfSqFGj7Lvvvjn77LMza9aszJ49e7V/jmtar1698vOf/zxdunRJ8sEZbD//+c9r/TK79LPKrFmz8te//nWdCqrmzp2bNm3apGnTppk2bVruu+++ZcY7dOiQX/ziF7n88svLf32xT58+ufnmm8t/aW3evHnL3HNoddV2jJozZ04GDBiQyy+/PAcccEDOO++88vhHX/OrW1uvXr3Knw9ef/31/P3vf19mnct7jbdo0SIdO3YsH7efeuqpQv8Sbm0/n+rq6gwcODCNGjXKsGHDlvllWEPZpz6qtu/ntVnZe3mvXr1y9dVX50tf+lLatWuX2bNn529/+1uDCaCWZ2Xvybvttluuvvrq7LbbbqmqqsoWW2yR0aNHr5WenAH1CfXu3Tt/+MMfst9++2XTTTdN9+7d8/TTT2fvvffOk08+mX79+pVvND5t2rQkWeHYuuipp57KLbfckjvuuCOtWrXKhRdemNNPPz133HFH4ZfHNG7cOOeee26OPfbYtGrVapkb5bVs2TLPP/98brjhhiTJ5ZdfnqqqqkycODE333xzKisrU1NTkwsuuCCVlZXZbbfd8otf/CIHH3xwevbsuUzCv9Q555xTPk23oqIiTZo0yTnnnJOtttoqp556ag477LC0bNmyfPO3+nbcccflmGOOSbNmzTJq1KiMGjXqY7U3adIkp5xyShYsWJBSqZTPf/7z+epXv/qxxzfEm5BXV1fn61//et5///0MHTo0rVu3TpJaXxM77rhjjj/++PTv3z8tWrRIr169stFGG9VT9R+3JrfXjTfemIEDB2bu3LmpqKhIu3bt8sMf/rCeO1xWbftvbfvo17/+9cyePbt8A9ZSqZRvfvObDepsvVV9Tdamqqoql19++TI3IW/fvn2Rpa8RX//613Pfffelb9++ad26dbp161b+Ut+/f/88//zzOfDAA7Ppppsuc5PS+ti2Kzqe11WrVq0yYsSIDBgwIEuWLEmrVq0ycuTI8nj37t3LofDSG34nyaWXXpqLL744X/va15J88CVn2LBhn/im66vznrjjjjvmxBNPzDe/+c20aNFimbN3V7Q9l/eeee2112bkyJH58Y9/nMWLF2errbbKqFGj6vXsvdq20TbbbJPvfe97OfbYY1NRUZGqqqqMGjVqmTMY1mY9b731Vjp27Jjbb789559/fpo1a5YRI0Yk+WD//8EPfpCTTjop1dXVWbx4cfr27Zudd955hc/1y1/+Mo899liaNGmSqqqq5X6uWRVHHHFELrnkktx4442rfBPyj6rr/rc6n7teeOGFXHbZZUk+uIz0e9/7Xtq2bZu2bduu1s9xTevVq1fOOuus8he9Xr165be//W2tZx5suumm+cY3vpG5c+fmhBNOWK3LuuvL0UcfndNOOy0HHXRQ2rZtu9wvt+3atcvNN9+c73znO1mwYEG+973v5ac//WkOO+ywVFRUpKKiIieffPIn/iMqm2yyyXKPUU2aNMmhhx6a7t27p0uXLvn2t7+d3/zmN/nmN7+ZY445Juecc06aNWuWyy67bLVrO/fcc3PWWWdl3Lhx2XLLLZcJEVf0Gh8xYkTOPvvs/PznP0/Hjh0LvZy5tp/PkUcemT/84Q/p2LFj+RcpXbt2zZAhQ1b72FS02r6f12Zl7+W77bZbfv/735f30W7duuXvf//7ci8bbihq255L35N32223XHnlleWeevXqlcmTJ2eXXXYpvLaKUn3/agoKsKK/LMWn27x588rB6NVXX51XX301l156aT1XBZ8OS/e/RYsW5aSTTkrfvn3L946gON4TG77HHnssw4cPz5133lnfpdCA9OnTJ6NGjSr03j8Aa5MzoIBPlcsuuyyTJ08u/yZg6NCh9V0SfGoce+yxWbRoURYuXJgvfelLy9yUGACA9ZszoAAAAAAolJuQAwAAAFAoARQAAAAAhRJAAQAAAFAoARQAwDru6KOPzu23317fZQAA1EoABQAAAEChBFAAAOuIUqmUmpqa+i4DAGCVCaAAAAry+9//PieeeGJ5+qtf/WpOPfXU8vSee+6Z5557LpMnT86hhx6abt265dBDD83kyZPLyxx99NG54oor0r9//3zxi1/M66+/nocffjh9+/ZNt27dMnTo0JRKpfLyr776ao466qh069Ytu+66a37wgx+slV4BAFZEAAUAUJCePXtm0qRJqampybRp07J48eI8+eSTSZLXX3898+fPT7t27XLCCSfk6KOPzmOPPZZjjz02J5xwQt55553yesaMGZMLL7wwkydPzkYbbZSTTz45P/jBD/Loo49m6623XiawuvLKK7P77rvn8ccfz4MPPpijjjpqbbcNAPAxAigAgIJstdVWad68eZ577rlMmjQpe+yxRzbffPO89NJLmThxYrp165YHHngg22yzTb7+9a+ncePGOeigg/KZz3wmf/nLX8rrOeSQQ/K5z30ujRs3zoMPPpjPfe5z6du3b5o0aZJvfetb2WyzzcrLNm7cOFOmTMn06dPTtGnTdO/evT5aBwBYhgAKAKBAPXr0yMSJE/P444+nR48e6dmzZx5//PE8/vjj6dmzZ6ZPn5727dsv85j27dtn2rRp5el27dqV/z99+vRsscUW5emKioplxs8888yUSqUcdthhOfDAA3PHHXcU2B0AQN00ru8CAADWZz179sz999+fN998MyeeeGI23njjjB07Nk888UT+93//Ny+99FKmTJmyzGOmTp2a3r17l6crKirK/2/Tpk3eeuut8nSpVMrUqVOXGb/ooouSJJMmTcqxxx6bHj16ZJtttimqRQCAlXIGFABAgXr06JHHHnssCxYsyBZbbJHu3bvnoYceyuzZs/P5z38+e+65Z1555ZWMHTs2S5Ysyfjx4/Of//wne+2113LXt+eee+bFF1/MvffemyVLluSWW27JjBkzyuP33HNPOaDaZJNNUlFRkcpKH/kAgPrl0wgAQIG22267NG/evHwvphYtWmTLLbdM165d06hRo2y66aYZNWpUbrrppuy666654YYbMmrUqLRq1Wq562vVqlWuvPLKXHbZZdl1113z6quvpmvXruXxp59+Oocffni6dOmSk046Keeee2622mqrtdIrAEBtKkof/ru9AAAAALCGOQMKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEIJoAAAAAAolAAKAAAAgEL9fyEQrX2hoyYZAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 1440x720 with 1 Axes>"
       ]
@@ -1072,12 +1116,16 @@
    ],
    "source": [
     "# what are the most commonly appearing words in the titles\n",
-    "words = pr_df[\"title\"].str.lower().str.cat(sep=\" \").split()\n",
-    "words = [w for w in words if w not in set(STOPWORDS)]\n",
+    "\n",
+    "# combin all titles and split into words\n",
+    "words = preproc_titles.str.cat(sep=\" \").split()\n",
+    "\n",
+    "# remove stopwords and numbers (e.g. bugzilla ids)\n",
+    "words = [w for w in words if w not in set(STOPWORDS) and not w.isnumeric()]\n",
     "\n",
     "# word frequencies\n",
-    "values, counts = np.unique(words, return_counts=True)\n",
-    "vc = pd.Series(counts, index=values).sort_values(ascending=False)\n",
+    "unique_words, counts = np.unique(words, return_counts=True)\n",
+    "vc = pd.Series(counts, index=unique_words).sort_values(ascending=False)\n",
     "\n",
     "# plot the 20 most common words\n",
     "sns.barplot(\n",
@@ -1092,63 +1140,51 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef9252ef-1316-47f2-a22d-4d2058414dda",
+   "id": "663836f1",
    "metadata": {},
    "source": [
-    "We can create categorical features from the above top words which are True or False depending on whether a certain top word is present or absent in the PR title. Alternatively, we can also create a feature which is a vector indicating how many times these prominent words appeared in the title."
+    "From the above graph, we can see that titles often contain some keywords that can hint towards the type of changes being made in the PR. We can create categorical features from the above top words which are True or False depending on whether a certain top word is present or absent in the PR title. Alternatively, we can also create a feature which is a vector indicating how many times each word appeared in the title. This way, even if a less prominent word is more correlated with time_to_merge, we will be able to capture that relationship."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 26,
-   "id": "d21b973a-daab-4fa3-87ca-76d68f6b1f73",
+   "id": "09358a64",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 7828/7828 [04:00<00:00, 32.57it/s]\n"
+     ]
+    }
+   ],
    "source": [
-    "# lets see if we can gain any meaningful information about a pr based on the title\n",
-    "\n",
-    "# is code being added, removed or updated?\n",
-    "pr_df[\"title_has_add\"] = pr_df[\"title\"].apply(lambda x: \"add\" in x.lower().split())\n",
-    "pr_df[\"title_has_remove\"] = pr_df[\"title\"].apply(\n",
-    "    lambda x: \"remove\" in x.lower().split()\n",
-    ")\n",
-    "pr_df[\"title_has_update\"] = pr_df[\"title\"].apply(\n",
-    "    lambda x: \"update\" in x.lower().split()\n",
-    ")\n",
-    "\n",
-    "# is the PR using some other technology to address the PR\n",
-    "pr_df[\"title_has_use\"] = pr_df[\"title\"].apply(lambda x: \"use\" in x.lower().split())\n",
-    "\n",
-    "# is something being fixed?\n",
-    "pr_df[\"title_has_fix\"] = pr_df[\"title\"].apply(\n",
-    "    lambda x: any(s in x.lower().split() for s in [\"fix\", \"fixes\"])\n",
-    ")\n",
-    "\n",
-    "# is this related to tests?\n",
-    "pr_df[\"title_has_test\"] = pr_df[\"title\"].apply(\n",
-    "    lambda x: any(s in x.lower().split() for s in [\"test\", \"tests\"])\n",
-    ")\n",
-    "\n",
-    "# is this related to upstream or release\n",
-    "pr_df[\"title_has_upstream\"] = pr_df[\"title\"].apply(\n",
-    "    lambda x: any(s in x.lower().split() for s in [\"upstream\", \"upstream:\"])\n",
-    ")\n",
-    "pr_df[\"title_has_release\"] = pr_df[\"title\"].apply(\n",
-    "    lambda x: \"release\" in x.lower().split()\n",
-    ")\n",
-    "\n",
-    "# is this related to config, image, or build\n",
-    "pr_df[\"title_has_config\"] = pr_df[\"title\"].apply(\n",
-    "    lambda x: \"config\" in x.lower().split()\n",
-    ")\n",
-    "pr_df[\"title_has_build\"] = pr_df[\"title\"].apply(lambda x: \"build\" in x.lower().split())\n",
-    "pr_df[\"title_has_image\"] = pr_df[\"title\"].apply(lambda x: \"image\" in x.lower().split())"
+    "# add word count columns\n",
+    "for word in tqdm(unique_words):\n",
+    "    pr_df[f'title_wordcount_{word}'] = preproc_titles.apply(lambda x: x.split().count(word))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "id": "4c7b1563-3423-4b55-82db-fbe5b1bdc0ce",
+   "execution_count": 28,
+   "id": "86605291",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# collapse the high dim vector into one column\n",
+    "wordcount_columns = [c for c in pr_df.columns if 'wordcount' in c]\n",
+    "pr_df['title_word_counts_vec'] = pr_df[wordcount_columns].apply(lambda x: x.tolist(), axis=1)\n",
+    "\n",
+    "# drop the individual wordcount columns\n",
+    "pr_df = pr_df.drop(columns=wordcount_columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "02114f4b",
    "metadata": {},
    "outputs": [
     {
@@ -1182,17 +1218,14 @@
        "      <th>merged_at</th>\n",
        "      <th>commits_number</th>\n",
        "      <th>changed_files_number</th>\n",
-       "      <th>...</th>\n",
-       "      <th>title_has_remove</th>\n",
-       "      <th>title_has_update</th>\n",
-       "      <th>title_has_use</th>\n",
-       "      <th>title_has_fix</th>\n",
-       "      <th>title_has_test</th>\n",
-       "      <th>title_has_upstream</th>\n",
-       "      <th>title_has_release</th>\n",
-       "      <th>title_has_config</th>\n",
-       "      <th>title_has_build</th>\n",
-       "      <th>title_has_image</th>\n",
+       "      <th>interactions</th>\n",
+       "      <th>reviews</th>\n",
+       "      <th>labels</th>\n",
+       "      <th>commits</th>\n",
+       "      <th>changed_files</th>\n",
+       "      <th>time_to_merge</th>\n",
+       "      <th>body_size</th>\n",
+       "      <th>title_word_counts_vec</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1208,17 +1241,14 @@
        "      <td>1619253940</td>\n",
        "      <td>2</td>\n",
        "      <td>135</td>\n",
-       "      <td>...</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>True</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
+       "      <td>{'deads2k': 1, 'openshift-ci-robot': 307, 'stt...</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>[approved, bugzilla/severity-urgent, bugzilla/...</td>\n",
+       "      <td>[13b0e99d5f35d85998af9f07eb0c5b7d6fcc0dd0, 0c3...</td>\n",
+       "      <td>[go.mod, go.sum, test/extended/apiserver/api_r...</td>\n",
+       "      <td>149511.0</td>\n",
+       "      <td>37</td>\n",
+       "      <td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>26099</th>\n",
@@ -1232,21 +1262,17 @@
        "      <td>1619113470</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>...</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
+       "      <td>{'openshift-ci-robot': 508, 'deads2k': 43, 'op...</td>\n",
+       "      <td>{}</td>\n",
+       "      <td>[approved, bugzilla/severity-high, bugzilla/va...</td>\n",
+       "      <td>[7bc10c83eea29010f3b735c41847d43a992f606c]</td>\n",
+       "      <td>[test/extended/prometheus/prometheus.go]</td>\n",
+       "      <td>21959.0</td>\n",
+       "      <td>30</td>\n",
+       "      <td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>2 rows × 28 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -1262,26 +1288,32 @@
        "26100  1619104429  1619253940  openshift-merge-robot  1619253940   \n",
        "26099  1619091511  1619113470  openshift-merge-robot  1619113470   \n",
        "\n",
-       "      commits_number changed_files_number  ... title_has_remove  \\\n",
-       "26100              2                  135  ...            False   \n",
-       "26099              1                    1  ...            False   \n",
+       "      commits_number changed_files_number  \\\n",
+       "26100              2                  135   \n",
+       "26099              1                    1   \n",
        "\n",
-       "      title_has_update title_has_use title_has_fix title_has_test  \\\n",
-       "26100            False         False         False           True   \n",
-       "26099            False         False         False          False   \n",
+       "                                            interactions reviews  \\\n",
+       "26100  {'deads2k': 1, 'openshift-ci-robot': 307, 'stt...      {}   \n",
+       "26099  {'openshift-ci-robot': 508, 'deads2k': 43, 'op...      {}   \n",
        "\n",
-       "       title_has_upstream  title_has_release  title_has_config  \\\n",
-       "26100               False              False             False   \n",
-       "26099               False              False             False   \n",
+       "                                                  labels  \\\n",
+       "26100  [approved, bugzilla/severity-urgent, bugzilla/...   \n",
+       "26099  [approved, bugzilla/severity-high, bugzilla/va...   \n",
        "\n",
-       "       title_has_build  title_has_image  \n",
-       "26100            False            False  \n",
-       "26099            False            False  \n",
+       "                                                 commits  \\\n",
+       "26100  [13b0e99d5f35d85998af9f07eb0c5b7d6fcc0dd0, 0c3...   \n",
+       "26099         [7bc10c83eea29010f3b735c41847d43a992f606c]   \n",
        "\n",
-       "[2 rows x 28 columns]"
+       "                                           changed_files  time_to_merge  \\\n",
+       "26100  [go.mod, go.sum, test/extended/apiserver/api_r...       149511.0   \n",
+       "26099           [test/extended/prometheus/prometheus.go]        21959.0   \n",
+       "\n",
+       "       body_size                              title_word_counts_vec  \n",
+       "26100         37  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...  \n",
+       "26099         30  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...  "
       ]
      },
-     "execution_count": 27,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1292,7 +1324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0fee4c8-8c87-4fcd-8a1c-c81ba845a944",
+   "id": "a575b3d2",
    "metadata": {},
    "source": [
     "**Created By**\n",
@@ -1303,7 +1335,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
-   "id": "6066f9a2-e309-44d4-9fde-f4b58659d145",
+   "id": "1dab4744",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1334,7 +1366,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
-   "id": "dbbfaf44-00fc-46db-85bc-afc115101aed",
+   "id": "a14db592",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1346,7 +1378,7 @@
   {
    "cell_type": "code",
    "execution_count": 30,
-   "id": "e1ac03aa-2e3e-4e45-a204-ba70466f8fdd",
+   "id": "bf7c32d2",
    "metadata": {},
    "outputs": [
     {
@@ -1486,7 +1518,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4f290ee-6aa3-411a-b839-c421355e8dfd",
+   "id": "ded09969",
    "metadata": {},
    "source": [
     "We also want to derive a feature called `num_prev_merged_prs` captures the number of PRs that the creator created before this PR."
@@ -1495,7 +1527,7 @@
   {
    "cell_type": "code",
    "execution_count": 31,
-   "id": "db2483cc-68c1-42c5-8672-0ef1c94de5ac",
+   "id": "6237071e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1520,7 +1552,7 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "id": "5bcdacb9-710d-4fd9-b9e6-879742d72866",
+   "id": "350885e5",
    "metadata": {},
    "outputs": [
     {
@@ -1656,7 +1688,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e0e5f8d-63c3-4c5b-a9dc-4e95aa7f0b96",
+   "id": "ef01d928",
    "metadata": {},
    "source": [
     "**Created At**\n",
@@ -1667,7 +1699,7 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "id": "03964ec4-cdee-4890-a875-7017bbc7c284",
+   "id": "d3e7180b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1691,7 +1723,7 @@
   {
    "cell_type": "code",
    "execution_count": 34,
-   "id": "fdc9e0a9-191d-4206-b53a-6db5a9446358",
+   "id": "17193732",
    "metadata": {},
    "outputs": [
     {
@@ -1827,7 +1859,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56e98230-029c-4e24-b07e-4271ab45f6cf",
+   "id": "3afe44c1",
    "metadata": {},
    "source": [
     "**Commits Number**  \n",
@@ -1837,7 +1869,7 @@
   {
    "cell_type": "code",
    "execution_count": 35,
-   "id": "52f6a6f4-7c64-4437-8e8c-a49bc6b7151e",
+   "id": "5c490d37",
    "metadata": {},
    "outputs": [
     {
@@ -1869,7 +1901,7 @@
   {
    "cell_type": "code",
    "execution_count": 36,
-   "id": "ef2ec6fa-fa17-4a2e-8513-6690aeeacd98",
+   "id": "dcb68a20",
    "metadata": {},
    "outputs": [
     {
@@ -1893,7 +1925,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c1efb7e-e459-4085-bffa-b618540055d6",
+   "id": "feb93201",
    "metadata": {},
    "source": [
     "As we see above, in this dataset, there is not much variability in the commits number. Majority of the PRs (77%) have 1 commit, 11% have 2 commits and rest(12%) have more than 2 commits. We can break commits number down into 3 categorical variables, `contains_1_commit`, `contains_2_commits`, `contains_3_or_more_commits`. However, there might be some value in knowing whether a PR had 5 commits vs. 10 commits. So we will treat it as a numerical variable to begin with."
@@ -1902,7 +1934,7 @@
   {
    "cell_type": "code",
    "execution_count": 37,
-   "id": "49b335e4-6430-4fde-b8c6-43c05be50e68",
+   "id": "fabb641e",
    "metadata": {},
    "outputs": [
     {
@@ -2038,7 +2070,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9618f87-c484-4b9a-89a6-f8b0b7350045",
+   "id": "247bfb1b",
    "metadata": {},
    "source": [
     "**Changed Files Number**  \n",
@@ -2048,7 +2080,7 @@
   {
    "cell_type": "code",
    "execution_count": 38,
-   "id": "6f42fab7-8297-404c-a9c8-685de3499ed3",
+   "id": "9ae7bbe2",
    "metadata": {},
    "outputs": [
     {
@@ -2083,7 +2115,7 @@
   {
    "cell_type": "code",
    "execution_count": 39,
-   "id": "d21e1b9c-52c3-412b-9743-34e76d602035",
+   "id": "360a8957",
    "metadata": {},
    "outputs": [
     {
@@ -2109,7 +2141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "080ca56b-f79b-4f6a-a50a-84f68fd3cde1",
+   "id": "b5f404d7",
    "metadata": {},
    "source": [
     "`changed_files_number` has more variability than the `commits_number`. We can incorporate this as a numerical feature."
@@ -2117,7 +2149,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5a6cd840-6b2d-4c3b-a8d2-372e93b28298",
+   "id": "5e3da7f8",
    "metadata": {},
    "source": [
     "**Changed_files**\n",
@@ -2128,7 +2160,7 @@
   {
    "cell_type": "code",
    "execution_count": 40,
-   "id": "cc2cbbd8-274c-4e7e-a0b2-72e4cc49d787",
+   "id": "dff11c91",
    "metadata": {},
    "outputs": [
     {
@@ -2156,8 +2188,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
-   "id": "0abc4293-fae6-4f29-aae4-7bf104435a09",
+   "execution_count": 29,
+   "id": "725deeed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2186,7 +2218,7 @@
   {
    "cell_type": "code",
    "execution_count": 42,
-   "id": "0be771e9-deb0-48f5-af8d-5c679decb856",
+   "id": "7c7968d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2197,7 +2229,7 @@
   {
    "cell_type": "code",
    "execution_count": 43,
-   "id": "29d668d8-6827-4583-a76f-47ce8f9ae82a",
+   "id": "4c49f2e7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2207,7 +2239,7 @@
   {
    "cell_type": "code",
    "execution_count": 44,
-   "id": "ecf99a61-366d-49ce-8f71-fa991beb45eb",
+   "id": "c4d9eca1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2217,7 +2249,7 @@
   {
    "cell_type": "code",
    "execution_count": 45,
-   "id": "059dc306-f396-4763-8cc1-5cba0829d12a",
+   "id": "08ca44f4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2229,7 +2261,7 @@
   {
    "cell_type": "code",
    "execution_count": 46,
-   "id": "e9c0c9ed-5d12-4d54-9f90-7f8b9a336d2a",
+   "id": "c234327e",
    "metadata": {},
    "outputs": [
     {
@@ -2348,8 +2380,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
-   "id": "bc2d9c24-5687-4438-9dd4-b90a7da7f4e2",
+   "execution_count": 27,
+   "id": "00277247",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2373,10 +2405,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
-   "id": "8acd6af5-733c-403b-971e-6d298a372756",
+   "execution_count": 28,
+   "id": "15489b5a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'filetype' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-28-1739fe30019c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m pr_df[\"changed_file_type_vec\"] = pr_df[\"changed_files\"].apply(\n\u001b[0m\u001b[1;32m      2\u001b[0m     \u001b[0;32mlambda\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mfile_type_freq\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m )\n",
+      "\u001b[0;32m/opt/app-root/lib64/python3.8/site-packages/pandas/core/series.py\u001b[0m in \u001b[0;36mapply\u001b[0;34m(self, func, convert_dtype, args, **kwds)\u001b[0m\n\u001b[1;32m   4136\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   4137\u001b[0m                 \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mastype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobject\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_values\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 4138\u001b[0;31m                 \u001b[0mmapped\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmap_infer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalues\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mconvert\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mconvert_dtype\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   4139\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   4140\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmapped\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmapped\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mSeries\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32mpandas/_libs/lib.pyx\u001b[0m in \u001b[0;36mpandas._libs.lib.map_infer\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-28-1739fe30019c>\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(x)\u001b[0m\n\u001b[1;32m      1\u001b[0m pr_df[\"changed_file_type_vec\"] = pr_df[\"changed_files\"].apply(\n\u001b[0;32m----> 2\u001b[0;31m     \u001b[0;32mlambda\u001b[0m \u001b[0mx\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mfile_type_freq\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mx\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m )\n",
+      "\u001b[0;32m<ipython-input-27-e535d0dea69d>\u001b[0m in \u001b[0;36mfile_type_freq\u001b[0;34m(list_of_filepaths)\u001b[0m\n\u001b[1;32m      8\u001b[0m     \"\"\"\n\u001b[1;32m      9\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m     \u001b[0mfile_extensions\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mfiletype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mf\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mlist_of_filepaths\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     11\u001b[0m     \u001b[0mext_dict\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;36m0\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mkey\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mtop_fileextensions\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     12\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0mf\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mfile_extensions\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-27-e535d0dea69d>\u001b[0m in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m      8\u001b[0m     \"\"\"\n\u001b[1;32m      9\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m     \u001b[0mfile_extensions\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0mfiletype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mf\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mlist_of_filepaths\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     11\u001b[0m     \u001b[0mext_dict\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;36m0\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mkey\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mtop_fileextensions\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     12\u001b[0m     \u001b[0;32mfor\u001b[0m \u001b[0mf\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mfile_extensions\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'filetype' is not defined"
+     ]
+    }
+   ],
    "source": [
     "pr_df[\"changed_file_type_vec\"] = pr_df[\"changed_files\"].apply(\n",
     "    lambda x: file_type_freq(x)\n",
@@ -2386,7 +2435,7 @@
   {
    "cell_type": "code",
    "execution_count": 49,
-   "id": "678a0b9a-6ef2-43e9-b65c-79a0b865e429",
+   "id": "977a0982",
    "metadata": {},
    "outputs": [
     {
@@ -2527,7 +2576,7 @@
   {
    "cell_type": "code",
    "execution_count": 50,
-   "id": "7c8a69a5-78c2-45c9-a629-8699c79680ea",
+   "id": "3749dbf2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2553,7 +2602,7 @@
   {
    "cell_type": "code",
    "execution_count": 51,
-   "id": "7e82e89a-d842-4e37-a5d0-2d42388f67de",
+   "id": "aad9b0df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2572,7 +2621,7 @@
   {
    "cell_type": "code",
    "execution_count": 52,
-   "id": "25573852-6aec-4bf0-ba63-7d5b5b764252",
+   "id": "67c40485",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2618,7 +2667,7 @@
   {
    "cell_type": "code",
    "execution_count": 53,
-   "id": "83b0c464-54c8-4426-abbb-bfb7fe4372de",
+   "id": "5e909b18",
    "metadata": {},
    "outputs": [
     {
@@ -2754,7 +2803,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a4966c9-34ff-40ce-b3f9-3b82dc5fc0d4",
+   "id": "e7b59b45",
    "metadata": {},
    "source": [
     "We can see above that some PRs have 0 for all directory fields since the directory structure of the repo has changed over time and we are interested in only the latest directory structure."
@@ -2762,7 +2811,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40d0a156-0f68-4fde-9b36-b3733aecd0bd",
+   "id": "ceb9d2aa",
    "metadata": {},
    "source": [
     "-----------------------------------"
@@ -2770,7 +2819,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c0d6861b-8b89-46e8-8f77-277f23bbb3cd",
+   "id": "0e706dcb",
    "metadata": {},
    "source": [
     "## Correlation Analysis"
@@ -2778,7 +2827,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b383061a",
+   "id": "377f54d7",
    "metadata": {},
    "source": [
     "Let's look at some pair-wise scatter plots of our data to see if there are any obvious correlations between our features. "
@@ -2787,7 +2836,7 @@
   {
    "cell_type": "code",
    "execution_count": 54,
-   "id": "5941f0be",
+   "id": "fe71342e",
    "metadata": {},
    "outputs": [
     {
@@ -2815,7 +2864,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70c7acd3",
+   "id": "4aabf71c",
    "metadata": {},
    "source": [
     "Its tough to see any meaningfull correlations here. Despite this \"L\" shaped scatter plot the vast majority of the points are centered around (0,0) in all 3 cases. Let's calculate the correlation value for each pair of variables to see some actaul numbers."
@@ -2824,7 +2873,7 @@
   {
    "cell_type": "code",
    "execution_count": 55,
-   "id": "a44641e2-d60d-4fb4-bd1c-3a8055470759",
+   "id": "69385517",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2873,7 +2922,7 @@
   {
    "cell_type": "code",
    "execution_count": 56,
-   "id": "0f185a61-22fb-4491-b602-469994cdb4f0",
+   "id": "d8ff544f",
    "metadata": {},
    "outputs": [
     {
@@ -3014,7 +3063,7 @@
   {
    "cell_type": "code",
    "execution_count": 57,
-   "id": "562de011-20a9-46c3-abb0-9a9c00c57a8d",
+   "id": "559a5515",
    "metadata": {},
    "outputs": [
     {
@@ -3313,7 +3362,7 @@
   {
    "cell_type": "code",
    "execution_count": 58,
-   "id": "c084de8f",
+   "id": "055c1bb4",
    "metadata": {},
    "outputs": [
     {
@@ -4418,7 +4467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d9a1ccb2",
+   "id": "156839d1",
    "metadata": {},
    "source": [
     "From the correlation values, above we do not see any strong correlation between `time to merge` and other variables. We can see that body_size is _most_ correlated with time_to_merge, but 0.11 is a rather weak correlation value. This is good if we are going to use these as input features to a model, but not so good if we wanted to try and predict one value from the other two.  As next [steps](https://github.com//issues/281), we will explore the correlation between the features in further detail to select the most important features for our model."
@@ -4426,7 +4475,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6d63ed7a",
+   "id": "44503449",
    "metadata": {},
    "source": [
     "### Conlusion\n",


### PR DESCRIPTION
## Related Issues and Dependencies

None

## This introduces a breaking change

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Update the feature extraction for title column to have just 1 numerical word frequency vector per PR, instead of boolean `title_has_xyz` columns. The frequency vector includes all words not just the top 20 words.